### PR TITLE
Add proposal for binding credential schema

### DIFF
--- a/specs/sb/api.md
+++ b/specs/sb/api.md
@@ -316,12 +316,12 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
 </thead>
 <tbody>
 <tr>
-  <td><a href="#SchemaObject">&nbsp;&nbsp;&nbsp;service_instance</a></td>
+  <td><a href="#SchemaObject">&nbsp;&nbsp;&nbsp;service_instances</a></td>
   <td>object</td>
   <td>The schema definitions for the input properties for a service instance.</td>
 </tr>
 <tr>
-  <td><a href="#SchemaObject">&nbsp;&nbsp;&nbsp;service_binding</a></td>
+  <td><a href="#SchemaObject">&nbsp;&nbsp;&nbsp;service_bindings</a></td>
   <td>object</td>
   <td>The schema definitions for the input properties for a service binding. Used only if the service is bindable.</td>
 </tr>
@@ -392,7 +392,7 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
         }]
       },
       "schemas": {
-        "service_instance": {
+        "service_instances": {
           "parameters": {
             "required": [
               "fake_required_property"
@@ -404,7 +404,7 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
             }
           }
         },
-        "service_binding": {
+        "service_bindings": {
           "parameters": {
             "properties": {
               "fake_binding_property": {
@@ -437,7 +437,7 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
         }]
       },
       "schemas": {
-        "service_instance": {
+        "service_instances": {
           "parameters": {
             "required": [
               "fake_required_property"
@@ -449,7 +449,7 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
             }
           }
         },
-        "service_binding": {
+        "service_bindings": {
           "parameters": {
             "properties": {
               "fake_binding_property": {

--- a/specs/sb/api.md
+++ b/specs/sb/api.md
@@ -296,6 +296,54 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
   <td>boolean</td>
   <td>This field allows the plan to be limited by the non_basic_services_allowed field in a Cloud Foundry Quota, see <a href="http://docs.cloudfoundry.org/running/managing-cf/quota-plans.md">Quota Plans</a>. Default: true</td>
 </tr>
+<tr>
+  <td><a href="#SchemasObject">&nbsp;&nbsp;&nbsp;schemas</a></td>
+  <td>object</td>
+  <td>The schema definitions for the input properties for service instances and bindings of the plan.</td>
+</tr>
+</tbody>
+</table>
+
+<h5> Schemas Object <a name="SchemasObject"></a> </h5>
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Response field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td><a href="#SchemaObject">&nbsp;&nbsp;&nbsp;service_instance</a></td>
+  <td>object</td>
+  <td>The schema definitions for the input properties for a service instance.</td>
+</tr>
+<tr>
+  <td><a href="#SchemaObject">&nbsp;&nbsp;&nbsp;service_binding</a></td>
+  <td>object</td>
+  <td>The schema definitions for the input properties for a service binding. Used only if the service is bindable.</td>
+</tr>
+</tbody>
+</table>
+
+<h5> Schema Object <a name="SchemaObject"></a> </h5>
+
+<table border="1" class="nice">
+<thead>
+<tr>
+  <th>Response field</th>
+  <th>Type</th>
+  <th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;parameters</td>
+  <td>object</td>
+  <td>The schema definitions for the input parameters. Schema definitions must be valid <a href="http://json-schema.org/">JSON Schema draft v4</a></td>
+</tr>
 </tbody>
 </table>
 
@@ -342,6 +390,29 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
         }, {
           "content": "40 concurrent connections"
         }]
+      },
+      "schemas": {
+        "service_instance": {
+          "parameters": {
+            "required": [
+              "fake_required_property"
+            ],
+            "properties": {
+              "fake_required_property": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "service_binding": {
+          "parameters": {
+            "properties": {
+              "fake_binding_property": {
+                "type": "string"
+              }
+            }
+          }
+        }
       }
     }, {
       "name": "fake-async-plan",
@@ -364,6 +435,29 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
         "bullets": [{
           "content": "40 concurrent connections"
         }]
+      },
+      "schemas": {
+        "service_instance": {
+          "parameters": {
+            "required": [
+              "fake_required_property"
+            ],
+            "properties": {
+              "fake_required_property": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "service_binding": {
+          "parameters": {
+            "properties": {
+              "fake_binding_property": {
+                "type": "string"
+              }
+            }
+          }
+        }
       }
     }]
   }]

--- a/specs/sb/api.md
+++ b/specs/sb/api.md
@@ -299,7 +299,7 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
 <tr>
   <td><a href="#SchemasObject">&nbsp;&nbsp;&nbsp;schemas</a></td>
   <td>object</td>
-  <td>The schema definitions for the input properties for service instances and bindings of the plan.</td>
+  <td>The schema definitions for the input and output properties for service instances and bindings of the plan.</td>
 </tr>
 </tbody>
 </table>
@@ -318,12 +318,12 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
 <tr>
   <td><a href="#SchemaObject">&nbsp;&nbsp;&nbsp;service_instances</a></td>
   <td>object</td>
-  <td>The schema definitions for the input properties for a service instance.</td>
+  <td>The schema definitions for the input and output properties for a service instance.</td>
 </tr>
 <tr>
   <td><a href="#SchemaObject">&nbsp;&nbsp;&nbsp;service_bindings</a></td>
   <td>object</td>
-  <td>The schema definitions for the input properties for a service binding. Used only if the service is bindable.</td>
+  <td>The schema definitions for the input and output properties for a service binding. Used only if the service is bindable.</td>
 </tr>
 </tbody>
 </table>
@@ -343,6 +343,11 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
   <td>&nbsp;&nbsp;&nbsp;parameters</td>
   <td>object</td>
   <td>The schema definitions for the input parameters. Schema definitions must be valid <a href="http://json-schema.org/">JSON Schema draft v4</a></td>
+</tr>
+<tr>
+  <td>&nbsp;&nbsp;&nbsp;outputs</td>
+  <td>object</td>
+  <td>The schema definitions for the output properties, currently only defined for bindings. Schema definitions must be valid <a href="http://json-schema.org/">JSON Schema draft v4</a></td>
 </tr>
 </tbody>
 </table>
@@ -402,12 +407,29 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
                 "type": "string"
               }
             }
+           }
           }
         },
         "service_bindings": {
           "parameters": {
             "properties": {
               "fake_binding_property": {
+                "type": "string"
+              }
+            }
+          },
+          "outputs": {
+            "properties": {
+              "hostname": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer"
+              },
+              "username": {
+                "type": "string"
+              },
+              "password": {
                 "type": "string"
               }
             }
@@ -453,6 +475,22 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
           "parameters": {
             "properties": {
               "fake_binding_property": {
+                "type": "string"
+              }
+            }
+          },
+          "outputs": {
+            "properties": {
+              "hostname": {
+                "type": "string"
+              },
+              "port": {
+                "type": "integer"
+              },
+              "username": {
+                "type": "string"
+              },
+              "password": {
                 "type": "string"
               }
             }


### PR DESCRIPTION
Service Binding outputs are a generic map of data, and must be
schematized in the same way that input parameters are. This allows
customers and tooling to reason about the expected output when binding
to a service instance of a particular service type.
