### PR TITLE
Fix release notes link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 ![Open Service Broker API](https://www.openservicebrokerapi.org/wp-content/uploads/2016/12/osbapi_logo_concept3_wtm.png)
 
 [The Open Service Broker API specification](_spec.md)
+
 [Release Notes for past versions](_release-notes.md)
 
 ## Communications

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Open Service Broker API](https://www.openservicebrokerapi.org/wp-content/uploads/2016/12/osbapi_logo_concept3_wtm.png)
 
 [The Open Service Broker API specification](_spec.md)
-[Release Notes for past versions](_release_notes.md)
+[Release Notes for past versions](_release-notes.md)
 
 ## Communications
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 ![Open Service Broker API](https://www.openservicebrokerapi.org/wp-content/uploads/2016/12/osbapi_logo_concept3_wtm.png)
 
-This repo contains the Open Service Broker API specification.
-
-The specification can be found [here](_spec.md).
+[The Open Service Broker API specification](_spec.md)
+[Release Notes for past versions](_release_notes.md)
 
 ## Communications
 

--- a/_spec.md
+++ b/_spec.md
@@ -1,4 +1,3 @@
-
 #Table of Contents#
   - [API Release Notes](#release-notes)
   - [Changes](#changes)
@@ -22,10 +21,6 @@
   - [Deprovisioning](#deprovisioning)
   - [Broker Errors](#broker-errors)
   - [Orphans](#orphans)
-
-<div id="release-notes"/>
-##API Release Notes##
-[Service Broker API Release Notes](release-notes.html)
 
 <div id="changes"/> 
 ## Changes ##


### PR DESCRIPTION
Because the release notes file name has an underscore (as it is embedded in the CF docs as a partial), a link to the release notes in the spec doesn't work both in this repo and in the CF docs. 

Moved the link out of the spec, and added it to the README. In the CF docs we'll add a link to the release notes by other means.