### PR TITLE
Point README.md at spec.md directly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Open Service Broker API](https://www.openservicebrokerapi.org/wp-content/uploads/2016/12/osbapi_logo_concept3_wtm.png)
 
-[The Open Service Broker API specification](_spec.md)
+[The Open Service Broker API specification](spec.md)
 
 [Release Notes for past versions](_release-notes.md)
 


### PR DESCRIPTION
GitHub does not follow symlinks and as such, the GitHub landing page
has a broken link.