### PR TITLE
Fix PullApprove metadata per our process change

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -5,7 +5,7 @@ reset_on_push: true
 signed_off_by:
   required: false
 reviewers:
-  required: 1
+  required: 4
   members:
     - duglin
     - bmelville


### PR DESCRIPTION
Now requires 4 LGTMs, not 1

Signed-off-by: Doug Davis <dug@us.ibm.com>