### PR TITLE
Support async binding operations

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -13,8 +13,9 @@
   - [Synchronous and Asynchronous Operations](#synchronous-and-asynchronous-operations)
     - [Synchronous Operations](#synchronous-operations)
     - [Asynchronous Operations](#asynchronous-operations)
-  - [Polling Last Operation](#polling-last-operation)
-    - [Polling Interval and Duration](#polling-interval-and-duration)
+  - [Polling Last Service Instance Operation](#polling-last-service-instance-operation)
+  - [Polling Last Service Binding Operation](#polling-last-service-binding-operation)
+  - [Polling Interval and Duration](#polling-interval-and-duration)
   - [Provisioning](#provisioning)
   - [Updating a Service Instance](#updating-a-service-instance)
   - [Binding](#binding)
@@ -85,23 +86,23 @@ Warnings for broker authors:
 
 The following sections describe catalog requests and responses in the Service Broker API.
 
-### Request ###
+### Request
 
-#### Route ####
+#### Route
 `GET /v2/catalog`
 
-#### cURL ####
+#### cURL
 <pre class="terminal">
  $ curl -H "X-Broker-API-Version: 2.11" http://username:password@broker-url/v2/catalog
 </pre>
 
-### Response ###
+### Response
 
-| Status Code  | Description  |
+| Status Code | Description |
 |---|---|
-| 200 OK  | The expected response body is below. |
+| 200 OK | The expected response body is below. |
 
-#### Body - Schema of Service Objects ####
+#### Body - Schema of Service Objects
 
 CLI and web clients have different needs with regard to service and plan names.
 A CLI-friendly string is all lowercase, with no spaces.
@@ -109,45 +110,44 @@ Keep it short -- imagine a user having to type it as an argument for a longer
 command.
 A web-friendly display name is camel-cased with spaces and punctuation supported.
 
-|  Response field | Type  | Description  |
+|  Response field | Type | Description |
 |---|---|---|
 |  services* |  array-of-service-objects |  Schema of service objects defined below. |
 
-##### Service Objects #####
+##### Service Objects
 
-|  Response field |  Type | Description  |
+|  Response field |  Type | Description |
 |---|---|---|
-|  name* | string  |  A CLI-friendly name of the service. All lowercase, no spaces. This MUST be globally unique within a platform marketplace. |
-| id*  |  string | An identifier used to correlate this service in future requests to the broker. This MUST be globally unique within a platform marketplace. Using a GUID is RECOMMENDED.  |
-|  description* |  string | A short description of the service.  |
-| tags  |  array-of-strings | Tags provide a flexible mechanism to expose a classification, attribute, or base technology of a service, enabling equivalent services to be swapped out without changes to dependent logic in applications, buildpacks, or other services. E.g. mysql, relational, redis, key-value, caching, messaging, amqp.  |
-|  requires | array-of-strings  | A list of permissions that the user would have to give the service, if they provision it. The only permissions currently supported are <code>syslog\_drain</code>, <code>route\_forwarding</code> and <code>volume\_mount</code>.  |
-| bindable*  | boolean  | Specifies whether instances of the service can be bound to applications. This specifies the default for all plans of this service. Plans can override this field (see [Plan Object](#PObject)).  |
-| metadata  |  JSON object | An opaque object of metadata for a service offering. Controller treats this as a blob. Note that there are (conventions)[https://docs.cloudfoundry.org/services/catalog-metadata.html] in existing brokers and controllers for fields that aid in the display of catalog data. |
-| [dashboard_client](#DObject)  |  object |  Contains the data necessary to activate the Dashboard SSO feature for this service |
-| plan\_updateable  | boolean  |  Whether the service supports upgrade/downgrade for some plans. Please note that the misspelling of the attribute <code>plan\_updatable</code> to <code>plan\_updateable</code> was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility.  |
-| [plans*](#PObject) | array-of-objects | A list of plans for this service, schema is defined below.|  |
+|  name* | string |  A CLI-friendly name of the service. All lowercase, no spaces. This MUST be globally unique within a platform marketplace. |
+| id* |  string | An identifier used to correlate this service in future requests to the broker. This MUST be globally unique within a platform marketplace. Using a GUID is RECOMMENDED. |
+|  description* |  string | A short description of the service. |
+| tags |  array-of-strings | Tags provide a flexible mechanism to expose a classification, attribute, or base technology of a service, enabling equivalent services to be swapped out without changes to dependent logic in applications, buildpacks, or other services. E.g. mysql, relational, redis, key-value, caching, messaging, amqp. |
+|  requires | array-of-strings | A list of permissions that the user would have to give the service, if they provision it. The only permissions currently supported are <code>syslog\_drain</code>, <code>route\_forwarding</code> and <code>volume\_mount</code>. |
+| bindable* | boolean | Specifies whether instances of the service can be bound to applications. This specifies the default for all plans of this service. Plans can override this field (see [Plan Object](#PObject)). |
+| metadata |  JSON object | An opaque object of metadata for a service offering. Controller treats this as a blob. Note that there are (conventions)[https://docs.cloudfoundry.org/services/catalog-metadata.html] in existing brokers and controllers for fields that aid in the display of catalog data. |
+| [dashboard_client](#DObject) |  object |  Contains the data necessary to activate the Dashboard SSO feature for this service |
+| plan\_updateable | boolean |  Whether the service supports upgrade/downgrade for some plans. Please note that the misspelling of the attribute <code>plan\_updatable</code> to <code>plan\_updateable</code> was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility. |
+| [plans*](#PObject) | array-of-objects | A list of plans for this service, schema is defined below.| |
 
-##### Dashboard Client Object <a name="DObject"></a> #####
+##### Dashboard Client Object
 
-| Response field  | Type  | Description  |
+| Response field | Type | Description |
 |---|---|---|
-| id  | string  | The id of the Oauth client that the dashboard will use.  |
-|  secret | string  | A secret for the dashboard client  |
-|  redirect_uri |  string | A URI for the service dashboard. Validated by the OAuth token server when the dashboard requests a token.  |
+| id | string | The id of the Oauth client that the dashboard will use. |
+|  secret | string | A secret for the dashboard client |
+|  redirect_uri |  string | A URI for the service dashboard. Validated by the OAuth token server when the dashboard requests a token. |
 
 
-##### Plan Object <a name="PObject"></a> #####
+##### Plan Object
 
-|  Response field | Type  | Description  |
+|  Response field | Type | Description |
 |---|---|---|
-| id*  | string  | An identifier used to correlate this plan in future requests to the broker. This MUST be globally unique within a platform marketplace. Using a GUID is RECOMMENDED.  |
-| name*  | string  | The CLI-friendly name of the plan. MUST be unique within the service. All lowercase, no spaces.  |
-| description*  | string  | A short description of the plan.  |
-|  metadata | JSON object  | An opaque object of metadata for a service plan. Controller treats this as a blob. Note that there are (conventions)[https://docs.cloudfoundry.org/services/catalog-metadata.html] in existing brokers and controllers for fields that aid in the display of catalog data. |
-| free  | boolean  | When false, instances of this plan have a cost. The default is true  |
-|  bindable | boolean  |  Specifies whether instances of the service plan can be bound to applications. This field is OPTIONAL. If specified, this takes precedence over the <tt>bindable</tt> attribute of the service. If not specified, the default is derived from the service. |
-
+| id* | string | An identifier used to correlate this plan in future requests to the broker. This MUST be globally unique within a platform marketplace. Using a GUID is RECOMMENDED. |
+| name* | string | The CLI-friendly name of the plan. MUST be unique within the service. All lowercase, no spaces. |
+| description* | string | A short description of the plan. |
+|  metadata | JSON object | An opaque object of metadata for a service plan. Controller treats this as a blob. Note that there are (conventions)[https://docs.cloudfoundry.org/services/catalog-metadata.html] in existing brokers and controllers for fields that aid in the display of catalog data. |
+| free | boolean | When false, instances of this plan have a cost. The default is true |
+|  bindable | boolean |  Specifies whether instances of the service plan can be bound to applications. This field is OPTIONAL. If specified, this takes precedence over the <tt>bindable</tt> attribute of the service. If not specified, the default is derived from the service. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -253,7 +253,7 @@ Brokers that support sychronous responses for provision, update, and delete can 
 
 ### Asynchronous Operations
 
-<p class='note'><strong>Note:</strong> Asynchronous operations are currently supported only for provision, update, and deprovision.</p>
+<p class='note'><strong>Note:</strong> Asynchronous operations are currently supported for provision, update, bind, unbind and deprovision.</p>
 
 For a broker to return an asynchronous response, the query parameter `accepts_incomplete=true` MUST be included the request. If the parameter is not included or is set to `false`, and the broker cannot fulfill the request synchronously (guaranteeing that the operation is complete on response), then the broker SHOULD reject the request with the status code `422 UNPROCESSABLE ENTITY` and the following body:
 
@@ -266,15 +266,17 @@ For a broker to return an asynchronous response, the query parameter `accepts_in
 
 If the query parameter described above is present, and the broker executes the request asynchronously, the broker MUST return the asynchronous response `202 ACCEPTED`. The response body SHOULD be the same as if the broker were serving the request synchronously.
 
-An asynchronous response triggers the platform marketplace to poll the endpoint `GET /v2/service_instances/:guid/last_operation` until the broker indicates that the requested operation has succeeded or failed. Brokers MAY include a status message with each response for the `last_operation` endpoint that provides visibility to end users as to the progress of the operation.
+An asynchronous response triggers the platform marketplace to poll the relevant `last_operation` until the broker indicates that the requested operation has succeeded or failed. Brokers MAY include a status message with each response for the `last_operation` endpoint that provides visibility to end users as to the progress of the operation.
+
+Once a broker has returned the asynchronous response `202 ACCEPTED`, the relevant `last_operation` endpoint MUST be ready to respond to polling requests immediately.
 
 #### Blocking Operations ####
 
 The marketplace MUST ensure that service brokers do not receive requests for an instance while an asynchronous operation is in progress. For example, if a broker is in the process of provisioning an instance asynchronously, the marketplace can not allow any update, bind, unbind, or deprovision requests to be made through the platform. A user who attempts to perform one of these actions while an operation is already in progress MUST receive an HTTP 400 response with the error message: `Another operation for this service instance is in progress`.
 
-## Polling Last Operation
+## Polling Last Service Instance Operation
 
-When a broker returns status code `202 ACCEPTED` for [provision](#provisioning), [update](#updating_service_instance), or [deprovision](#deprovisioning), the platform will begin polling the `/v2/service_instances/:guid/last_operation` endpoint to obtain the state of the last requested operation. The broker response MUST contain the field `state` and MAY contain the field `description`.
+When a broker returns status code `202 ACCEPTED` for [provision](#provisioning), [update](#updating_service_instance) or [deprovision](#deprovisioning), the platform will begin polling the `/v2/service_instances/:instance_id/last_operation` endpoint to obtain the state of the last requested operation. The broker response MUST contain the field `state` and an optional field `description`.
 
 Valid values for `state` are `in progress`, `succeeded`, and `failed`. The platform will poll the `last_operation` endpoint as long as the broker returns `"state": "in progress"`. Returning `"state": "succeeded"` or `"state": "failed"` will cause the platform to cease polling. The value provided for `description` will be passed through to the platform API client and can be used to provide additional detail for users about the progress of the operation.
 
@@ -287,11 +289,11 @@ Valid values for `state` are `in progress`, `succeeded`, and `failed`. The platf
 
 The request provides these query string parameters as useful hints for brokers.
 
-|  Query-String Field | Type  | Description  |
+|  Query-String Field | Type | Description |
 |---|---|---|
-| service_id  |  string | ID of the service from the catalog.  |
-| plan_id  | string  | ID of the plan from the catalog.  |
-| operation  |  string | A broker-provided identifier for the operation. When a value for <code>operation</code> is included with asynchronous responses for [Provision](#provisioning), [Update](#updating_service_instance), and [Deprovision](#deprovisioning) requests, the broker client SHOULD provide the same value using this query parameter as a URL-encoded string.  |
+| service_id |  string | ID of the service from the catalog. |
+| plan_id | string | ID of the plan from the catalog. |
+| operation |  string | A broker-provided identifier for the operation. When a value for <code>operation</code> is included with asynchronous responses for [Provision](#provisioning), [Update](#updating_service_instance), and [Deprovision](#deprovisioning) requests, the broker client SHOULD provide the same value using this query parameter as a URL-encoded string. |
 
 <p class="note"><strong>Note:</strong> Although the request query parameters <code>service_id</code> and <code>plan_id</code> are not mandatory, the platform SHOULD include them on all <code>last_operation</code> requests it makes to service brokers.</p>
 
@@ -302,10 +304,59 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id/las
 
 ### Response ###
 
-| Status Code  |  Description |
+| Status Code |  Description |
 |---|---|
 | 200 OK |  The expected response body is below. |
-|  410 GONE | Appropriate only for asynchronous delete operations. The platform MUST consider this response a success and remove the resource from its database. The expected response body is <code>{}</code>. Returning this while the platform is polling for create or update operations SHOULD be interpreted as an invalid response and the platform SHOULD continue polling.  |
+|  410 GONE | Appropriate only for asynchronous delete operations. The platform MUST consider this response a success and remove the resource from its database. The expected response body is <code>{}</code>. Returning this while the platform is polling for create or update operations SHOULD be interpreted as an invalid response and the platform SHOULD continue polling. |
+
+Responses with any other status code SHOULD be interpreted as an error or invalid response. The platform SHOULD continue polling until the broker returns a valid response or the [maximum polling duration](#polling-interval-and-duration) is reached. Brokers MAY use the `description` field to expose user-facing error messages about the operation state; for more info see [Broker Errors](#broker-errors).
+
+##### Body #####
+
+All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+
+For success responses, the following fields are valid.
+
+|  Response field | Type | Description |
+|---|---|---|
+| state* | string | Valid values are <code>in progress</code>, <code>succeeded</code>, and <code>failed</code>. While <code>"state": "in progress"</code>, the platform SHOULD continue polling. A response with <code>"state": "succeeded"</code> or <code>"state": "failed"</code> SHOULD cause the platform to cease polling. |
+| description | string | Optional field. A user-facing message displayed to the platform API client. Can be used to tell the user details about the status of the operation. |
+
+\* Fields with an asterisk are REQUIRED.
+
+## Polling Last Service Binding Operation
+
+When a broker returns status code `202 ACCEPTED` for [bind](#binding) or [unbind](#unbinding), the platform will begin polling the `/v2/service_instances/:instance_id/service_bindings/:binding_id/last_operation` endpoint to obtain the state of the last requested operation. The broker response MUST contain the field `state` and an optional field `description`.
+
+Valid values for `state` are `in progress`, `succeeded`, and `failed`. The platform will poll the `last_operation` endpoint as long as the broker returns `"state": "in progress"`. Returning `"state": "succeeded"` or `"state": "failed"` will cause the platform to cease polling. The value provided for `description` will be passed through to the platform API client and can be used to provide additional detail for users about the progress of the operation.
+
+### Request ###
+
+##### Route #####
+`GET /v2/service_instances/:instance_id/service_bindings/:binding_id/last_operation`
+
+##### Parameters #####
+
+The request provides these query string parameters as useful hints for brokers.
+
+|  Query-String Field | Type | Description |
+|---|---|---|
+| service_id |  string | ID of the service from the catalog. |
+| plan_id | string | ID of the plan from the catalog. |
+| operation |  string | A broker-provided identifier for the operation. When a value for <code>operation</code> is included with asynchronous responses for [Binding](#binding) and [Unbinding](#unbinding) requests, the platform SHOULD provide the same value using this query parameter as a URL-encoded string. |
+
+<p class="note"><strong>Note:</strong> Although the request query parameters <code>service_id</code> and <code>plan_id</code> are not mandatory, the platform SHOULD include them on all <code>last_operation</code> requests it makes to service brokers.</p>
+
+##### cURL #####
+<pre class="terminal">
+$ curl http://username:password@broker-url/v2/service_instances/:instance_id/service_bindings/:binding_id/last_operation
+</pre>
+
+### Response ###
+
+| Status Code |  Description |
+|---|---|
+| 200 OK |  The expected response body is below. |
 
 Responses with any other status code SHOULD be interpreted as an error or invalid response. The platform SHOULD continue polling until the broker returns a valid response or the [maximum polling duration](#polling-interval-and-duration) is reached. Brokers MAY use the `description` field to expose user-facing error messages about the operation state; for more info see [Broker Errors](#broker-errors).
 
@@ -315,17 +366,22 @@ All response bodies MUST be a valid JSON Object (`{}`). This is for future compa
 
 For success responses, the following fields are valid.
 
-|  Response field | Type  | Description  |
+|  Response field | Type | Description |
 |---|---|---|
-| state*  | string  | Valid values are <code>in progress</code>, <code>succeeded</code>, and <code>failed</code>. While <code>"state": "in progress"</code>, the platform SHOULD continue polling. A response with <code>"state": "succeeded"</code> or <code>"state": "failed"</code> MUST cause the platform to cease polling.  |
-|  description |  string | OPTIONAL field. A user-facing message displayed to the platform API client. Can be used to tell the user details about the status of the operation.  |
+| state* | string | Valid values are <code>in progress</code>, <code>succeeded</code>, and <code>failed</code>. While <code>"state": "in progress"</code>, the platform SHOULD continue polling. A response with <code>"state": "succeeded"</code> or <code>"state": "failed"</code> MUST cause the platform to cease polling. |
+|  description |  string | OPTIONAL field. A user-facing message displayed to the platform API client. Can be used to tell the user details about the status of the operation. |
+| credentials | object |  A free-form hash of credentials that may be used by applications or users to access the service. |
+| syslog\_drain_url | string | A URL to which logs may be streamed. <code>"requires":["syslog\_drain"]</code> MUST be declared in the [Catalog](#catalog-mgmt) endpoint or the platform SHOLD consider the response invalid. |
+| route\_service_url | string |  A URL to which the platform may proxy requests for the address sent with <code>bind\_resource.route</code> in the request body. <code>"requires":["route\_forwarding"]</code> MUST be declared in the [Catalog](#catalog-mgmt) endpoint or the platform SHOULD consider the response invalid. |
+| volume\_mounts | array-of-objects | An array of configuration for mounting volumes. <code>"requires":["volume_mount"]</code> MUST be declared in the [Catalog](#catalog-mgmt) endpoint or the platform SHOULD consider the response invalid. |
 
 \* Fields with an asterisk are REQUIRED.
 
+*Example response (binding in progress)*
 <pre class="terminal">
 {
   "state": "in progress",
-  "description": "Creating service (10% complete)."
+  "description": "Binding service (10% complete)."
 }
 </pre>
 
@@ -345,17 +401,17 @@ When the broker receives a provision request from the platform, it MUST take wha
 The `:instance_id` of a service instance is provided by the platform. This ID will be used for future requests (bind and deprovision), so the broker will use it to correlate the resource it creates.
 
 #### Parameters ####
-| Parameter name  | Type  |  Description |
+| Parameter name | Type |  Description |
 |---|---|---|
-|  accepts_incomplete | boolean  | A value of true indicates that the marketplace and its clients support asynchronous broker operations. If this parameter is not included in the request, and the broker can only provision an instance of the requested plan asynchronously, the broker should reject the request with a 422 as described below.  |
+|  accepts_incomplete | boolean | A value of true indicates that the marketplace and its clients support asynchronous broker operations. If this parameter is not included in the request, and the broker can only provision an instance of the requested plan asynchronously, the broker SHOULD reject the request with a 422 as described below. |
 
 
 ##### Body #####
-| Request field  | Type  |  Description |
+| Request field | Type |  Description |
 |---|---|---|
-| service_id*  | string  | The ID of the service (from the catalog). MUST be globally unique.  |
-| plan_id*  | string  | The ID of the plan (from the catalog) for which the service instance has been requested. MUST be unique to a service.  |
-| organization_guid*  | string  | The platform GUID for the organization under which the service is to be provisioned. Although most brokers will not use this field, it might be helpful for executing operations on a user's behalf.  |
+| service_id* | string | The ID of the service (from the catalog). MUST be globally unique. |
+| plan_id* | string | The ID of the plan (from the catalog) for which the service instance has been requested. MUST be unique to a service. |
+| organization_guid* | string | The platform GUID for the organization under which the service is to be provisioned. Although most brokers will not use this field, it might be helpful for executing operations on a user's behalf. |
 |  space_guid* |  string |  The identifier for the project space within the platform organization. Although most brokers will not use this field, it might be helpful for executing operations on a user's behalf. |
 |  parameters |  JSON object | Configuration options for the service instance. Controller treats this as a blob. Note that there are (conventions)[https://docs.cloudfoundry.org/services/catalog-metadata.html] in existing brokers and controllers for fields that aid in the display of catalog data. |
 
@@ -388,29 +444,25 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id?acc
 }' -X PUT -H "X-Broker-API-Version: 2.11" -H "Content-Type: application/json"
 </pre>
 
-### Response ###
+### Response
 
-| Status Code  | Description  |
-|---|---|
-| 201 Created  | Service instance has been provisioned. The expected response body is below.  |
-| 200 OK  |  MAY be returned if the service instance already exists and the requested parameters are identical to the existing service instance. The expected response body is below. |
-| 202 Accepted  | Service instance provisioning is in progress. This triggers the platform marketplace to poll the [Service Instance Last Operation Endpoint](#polling) for operation status.  |
-| 409 Conflict  | MUST be returned if a service instance with the same id already exists but with different attributes. The expected response body is <code>{}</code>.  |
-| 422 Unprocessable Entity  | MUST be returned if the broker only supports asynchronous provisioning for the requested plan and the request did not include <code>?accepts_incomplete=true</code>. The expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code>, as described below.  |
-
+| 200 OK |  MAY be returned if the service instance already exists and the requested parameters are identical to the existing service instance. The expected response body is below. |
+| 202 Accepted | Service instance provisioning is in progress. This triggers the platform marketplace to poll the [Last Service Instance Operation](#polling-last-service-instance-operation) for operation status. |
+| 409 Conflict | MUST be returned if a service instance with the same id already exists but with different attributes. The expected response body is <code>{}</code>. |
+| 422 Unprocessable Entity | MUST be returned if the broker only supports asynchronous provisioning for the requested plan and the request did not include <code>?accepts_incomplete=true</code>. The expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code>, as described below. |
 
 Responses with any other status code will be interpreted as a failure. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
-##### Body #####
+##### Body
 
 All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
 
 For success responses, a broker MUST return the following fields. For error responses, see [Broker Errors](#broker-errors).
 
-| Response field  |  Type | Description  |
+| Response field |  Type | Description |
 |---|---|---|
-|  dashboard_url | string  |  The URL of a web-based management user interface for the service instance; we refer to this as a service dashboard. The URL MUST contain enough information for the dashboard to identify the resource being accessed (<code>9189kdfsk0vfnku</code> in the example below).  Note: a broker that wishes to return `dashboard_url` for a service instance MUST return it with the initial response to the provision request, even if the service is provisioned asynchronously. |
-|  operation |  string | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field SHOULD be provided by the broker client with requests to the [Last Operation](#polling) endpoint in a URL encoded query parameter.  |
+|  dashboard_url | string |  The URL of a web-based management user interface for the service instance; we refer to this as a service dashboard. The URL MUST contain enough information for the dashboard to identify the resource being accessed (<code>9189kdfsk0vfnku</code> in the example below).  Note: a broker that wishes to return `dashboard_url` for a service instance MUST return it with the initial response to the provision request, even if the service is provisioned asynchronously. |
+|  operation |  string | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field SHOULD be provided by the broker client with requests to the [Last Service Instance Operation](#polling-last-service-binding-operation) endpoint in a URL encoded query parameter. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -429,30 +481,30 @@ To enable support for the update of the plan, a broker MUST declare support per 
 
 Not all permutations of plan changes are expected to be supported. For example, a service might support upgrading from plan "shared small" to "shared large" but not to plan "dedicated". It is up to the broker to validate whether a particular permutation of plan change is supported. If a particular plan change is not supported, the broker SHOULD return a meaningful error message in response.
 
-### Request ###
+### Request
 
-##### Route #####
+##### Route
 `PATCH /v2/service_instances/:instance_id`
 
 `:instance_id` is the global unique ID of a previously-provisioned service instance.
 
-#### Parameters ####
+#### Parameters
 | Parameter name | Type | Description |
 |---|---|---|
-| accepts\_incomplete | boolean | A value of true indicates that the marketplace and its clients support asynchronous broker operations. If this parameter is not included in the request, and the broker can only provision an instance of the requested plan asynchronously, the broker should reject the request with a 422 as described below.  |
+| accepts\_incomplete | boolean | A value of true indicates that the marketplace and its clients support asynchronous broker operations. If this parameter is not included in the request, and the broker can only provision an instance of the requested plan asynchronously, the broker SHOULD reject the request with a 422 as described below. |
 
-##### Body #####
+##### Body
 
-| Request Field  | Type  |  Description |
+| Request Field | Type | Description |
 |---|---|---|
-| service\_id*  | string  | The ID of the service (from the catalog). MUST be globally unique.  |
-| plan\_id  | string  | The ID of the plan (from the catalog) for which the service instance has been requested. MUST be unique to a service.  |
-| parameters  | JSON object  | Configuration options for the service instance. An opaque object, controller treats this as a blob. |
-| previous\_values  | object  |  Information about the instance prior to the update. |
-| previous\_values.service_id  | string  | ID of the service for the instance.  |
-| previous\_values.plan_id  |  string | ID of the plan prior to the update.  |
-| previous\_values.organization_id  | string  | ID of the organization specified for the instance.  |
-| previous\_values.space_id  | string  | ID of the space specified for the instance.  |
+| service\_id* | string | The ID of the service (from the catalog). MUST be globally unique. |
+| plan\_id | string | The ID of the plan (from the catalog) for which the service instance has been requested. MUST be unique to a service. |
+| parameters | JSON object | Configuration options for the service instance. |
+| previous\_values | object |  Information about the instance prior to the update. |
+| previous\_values.service_id | string | ID of the service for the instance. |
+| previous\_values.plan_id |  string | ID of the plan prior to the update. |
+| previous\_values.organization_id | string | ID of the organization specified for the instance. |
+| previous\_values.space_id | string | ID of the space specified for the instance. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -473,7 +525,7 @@ Not all permutations of plan changes are expected to be supported. For example, 
 }
 </pre>
 
-##### cURL #####
+##### cURL
 <pre class="terminal">
 $ curl http://username:password@broker-url/v2/service_instances/:instance_id?accepts_incomplete=true -d '{
   "service_id": "service-guid-here",
@@ -491,25 +543,25 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id?acc
 }' -X PATCH -H "X-Broker-API-Version: 2.11" -H "Content-Type: application/json"
 </pre>
 
-### Response ###
+### Response
 
-| Status Code  | Description  |
+| Status Code | Description |
 |---|---|
-| 200 OK  | The requests changes have been applied. The expected response body is <code>{}</code>.  |
-| 202 Accepted  |  Service instance update is in progress. This triggers the platform marketplace to poll the [Service Instance Last Operation Endpoint](#polling) for operation status. |
-| 422 Unprocessable entity  | MUST be returned if the requested change is not supported or if the request cannot currently be fulfilled due to the state of the instance (e.g. instance utilization is over the quota of the requested plan). Broker SHOULD include a user-facing message in the body; for details see [Broker Errors](#broker-errors).  Additionally, a 422 can also be returned if the broker only supports asynchronous update for the requested plan and the request did not include <code>?accepts_incomplete=true</code>; in this case the expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code>  |
+| 200 OK | The requests changes have been applied. The expected response body is <code>{}</code>. |
+| 202 Accepted |  Service instance update is in progress. This triggers the platform marketplace to poll the [Last Service Instance Operation](#polling-last-service-instance-operation) for operation status. |
+| 422 Unprocessable entity | MUST be returned if the requested change is not supported or if the request cannot currently be fulfilled due to the state of the instance (e.g. instance utilization is over the quota of the requested plan). Broker SHOULD include a user-facing message in the body; for details see [Broker Errors](#broker-errors).  Additionally, a 422 can also be returned if the broker only supports asynchronous update for the requested plan and the request did not include <code>?accepts_incomplete=true</code>; in this case the expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code> |
 
 Responses with any other status code will be interpreted as a failure. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
-##### Body #####
+##### Body
 
 All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
 
 For success responses, a broker MUST return the following field. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
 
-| Response field  | Type  | Description  |
+| Response field | Type | Description |
 |---|---|---|
-| operation  | string  |  For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field SHOULD be provided by the broker client with requests to the [Last Operation](#polling) endpoint in a URL encoded query parameter. |
+| operation | string | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field SHOULD be provided by the broker client with requests to the [Last Service Instance Operation](#polling-last-service-instance-operation) endpoint in a URL encoded query parameter. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -528,11 +580,11 @@ If `bindable:true` is declared for a service or plan in the [Catalog](#catalog-m
 
 ### Types of Binding
 
-#### Credentials ####
+#### Credentials
 
 Credentials are a set of information used by an application or a user to utilize the service instance. If the broker supports generation of credentials it MUST return `credentials` in the response for a request to create a service binding. Credentials SHOULD be unique whenever possible, so access can be revoked for each binding without affecting consumers of other bindings for the service instance.
 
-#### Log Drain ####
+#### Log Drain
 
 There are a class of service offerings that provide aggregation, indexing, and analysis of log data. To utilize these services an application that generates logs needs information for the location to which it will stream logs. If a broker represents one of these services, it MAY return a `syslog_drain_url` in the response for a request to create a service binding, to which logs MUST be streamed.
 
@@ -546,29 +598,29 @@ Some platforms MAY support proxying of application requests to service instances
 
 The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate requests to create bindings. A platform MAY reject requests to create bindings when a broker has declared `"requires":["route_forwarding"]` for a service in the catalog endpoint.
 
-#### Volume Services ####
+#### Volume Services
 
 There are a class of services that provide network storage to applications via volume mounts in the application container. A service broker MUST return data needed for this configuration with `volume_mount` in response to the request to create a binding.
 
 The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate a response for create binding that includes a `volume_mounts`. Platform marketplaces can consider a broker's response invalid if it includes a `volume_mounts` and `"requires":["volume_mount"]` is not present in the [Catalog](#catalog-mgmt) endpoint.
 
-### Request ###
+### Request
 
-##### Route #####
+##### Route
 `PUT /v2/service_instances/:instance_id/service_bindings/:binding_id`
 
 The `:instance_id` is the ID of a previously-provisioned service instance. The `:binding_id` is also provided by the platform. This ID will be used for future unbind requests, so the broker will use it to correlate
 the resource it creates.
 
-##### Body #####
+##### Body
 
-| Request Field  | Type  | Description  |
+| Request Field | Type | Description |
 |---|---|---|
-| service_id*  | string  | ID of the service from the catalog.  |
-| plan_id*  | string  | ID of the plan from the catalog.  |
-| app_guid  | string  | Deprecated in favor of <code>bind\_resource.app\_guid</code>. GUID of an application associated with the binding to be created.  |
-| bind_resource  | JSON object  | A JSON object that contains data for platform resources associated with the binding to be created. Current valid values include <code>app\_guid</code> for [credentials](#types-of-binding) and <code>route</code> for [route services](#route_services).  |
-| parameters | JSON object  |  Configuration options for the service binding. An opaque object, controller treats this as a blob.  |   |
+| service_id* | string | ID of the service from the catalog. |
+| plan_id* | string | ID of the plan from the catalog. |
+| app_guid | string | Deprecated in favor of <code>bind\_resource.app\_guid</code>. GUID of an application associated with the binding to be created. |
+| bind_resource | JSON object | A JSON object that contains data for platform resources associated with the binding to be created. Current valid values include <code>app\_guid</code> for [credentials](#types-of-binding) and <code>route</code> for [route services](#route_services). |
+| parameters | JSON object |  Configuration options for the service binding. An opaque object, controller treats this as a blob. |  |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -587,7 +639,7 @@ the resource it creates.
 </pre>
 
 
-##### cURL #####
+##### cURL
 <pre class="terminal">
 $ curl http://username:password@broker-url/v2/service_instances/:instance_id/service_bindings/:binding_id -d '{
   "service_id": "service-guid-here",
@@ -602,29 +654,31 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id/ser
 }' -X PUT
 </pre>
 
-### Response ###
+### Response
 
-| Status Code  | Description  |
+| Status Code | Description |
 |---|---|
-| 201 Created  |  Binding has been created. The expected response body is below. |
-| 200 OK  |  MUST be returned if the binding already exists and the requested parameters are identical to the existing binding. The expected response body is below. |
-| 409 Conflict  | MUST be returned if the requested binding already exists. The expected response body is <code>{}</code>, though the description field MAY be used to return a user-facing error message, as described in [Broker Errors](#broker-errors).  |
-| 422 Unprocessable Entity  | MUST be returned if the broker requires that <code>app_guid</code> be included in the request body. The expected response body is: <code>{ "error": "RequiresApp", "description": "This service supports generation of credentials through binding an application only." }</code>  |
+| 201 Created | Binding has been created. The expected response body is below. |
+| 200 OK |  MUST be returned if the binding already exists and the requested parameters are identical to the existing binding. The expected response body is below. |
+| 202 Accepted | Service instance binding is in progress. This triggers the platform marketplace to poll the [Last Service Binding Operation Endpoint](#polling-last-service-binding-operation) for operation status. |
+| 409 Conflict | MUST be returned if the requested binding already exists. The expected response body is <code>{}</code>, though the description field MAY be used to return a user-facing error message, as described in [Broker Errors](#broker-errors). |
+| 422 Unprocessable Entity | MUST be returned if the broker requires that <code>app_guid</code> be included in the request body. The expected response body is: <code>{ "error": "RequiresApp", "description": "This service supports generation of credentials through binding an application only." }</code> |
 
 Responses with any other status code will be interpreted as a failure and an unbind request will be sent to the broker to prevent an orphan being created on the broker. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
-##### Body #####
+##### Body
 
 All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
 
 For success responses, the following fields are supported. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
 
-|  Response Field | Type  | Description  |
+| Response Field | Type | Description |
 |---|---|---|
-| credentials  | object  |  A free-form hash of credentials that can be used by applications or users to access the service. |
-| syslog\_drain_url  | string  | A URL to which logs MUST be streamed. <code>"requires":["syslog\_drain"]</code> MUST be declared in the [Catalog](#catalog-mgmt) endpoint or the platform MUST consider the response invalid.  |
-| route\_service_url  | string  |  A URL to which the platform MUST proxy requests for the address sent with <code>bind\_resource.route</code> in the request body. <code>"requires":["route\_forwarding"]</code> MUST be declared in the [Catalog](#catalog-mgmt) endpoint or the platform can consider the response invalid. |
-| volume\_mounts  | array-of-objects  | An array of configuration for mounting volumes. <code>"requires":["volume_mount"]</code> MUST be declared in the [Catalog](#catalog-mgmt) endpoint or the platform can consider the response invalid.  |
+| credentials | object | A free-form hash of credentials that can be used by applications or users to access the service. |
+| syslog\_drain_url | string | A URL to which logs MUST be streamed. <code>"requires":["syslog\_drain"]</code> MUST be declared in the [Catalog](#catalog-mgmt) endpoint or the platform MUST consider the response invalid. |
+| route\_service_url | string | A URL to which the platform MUST proxy requests for the address sent with <code>bind\_resource.route</code> in the request body. <code>"requires":["route\_forwarding"]</code> MUST be declared in the [Catalog](#catalog-mgmt) endpoint or the platform can consider the response invalid. |
+| volume\_mounts | array-of-objects | An array of configuration for mounting volumes. <code>"requires":["volume_mount"]</code> MUST be declared in the [Catalog](#catalog-mgmt) endpoint or the platform can consider the response invalid. |
+| operation | string | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field SHOULD be provided by the platform with requests to the [Last Service Binding Operation](#polling-last-service-binding-operation) endpoint in a URL encoded query parameter. |
 
 <pre class="terminal">
     {
@@ -635,7 +689,8 @@ For success responses, the following fields are supported. Others will be ignore
         "host": "mysqlhost",
         "port": 3306,
         "database": "dbname"
-      }
+      },
+      "operation": "task_10"
     }
 </pre>
 
@@ -645,44 +700,57 @@ For success responses, the following fields are supported. Others will be ignore
 
 When a broker receives an unbind request from the marketplace, it MUST delete any resources associated with the binding. In the case where credentials were generated, this might result in requests to the service instance failing to authenticate.
 
-### Request ###
+### Request
 
-##### Route #####
+##### Route
 `DELETE /v2/service_instances/:instance_id/service_bindings/:binding_id`
 
 The `:instance_id` is the ID of a previously-provisioned service instance. The `:binding_id` is the ID of a previously provisioned binding for that instance.
 
-##### Parameters #####
+##### Parameters
 
 The request provides these query string parameters as useful hints for brokers.
 
-| Query-String Field  | Type  | Description |
+| Query-String Field | Type | Description |
 |---|---|---|
-| service_id*  | string | ID of the service from the catalog. |
-| plan_id*  | string  | ID of the plan from the catalog. |
+| service_id* | string | ID of the service from the catalog. |
+| plan_id* | string | ID of the plan from the catalog. |
 
 \* Query parameters with an asterisk are REQUIRED.
 
-##### cURL #####
+##### cURL
 <pre class="terminal">
 $ curl 'http://username:password@broker-url/v2/service_instances/:instance_id/
   service_bindings/:binding_id?service_id=service-id-here&plan_id=plan-id-here' -X DELETE -H "X-Broker-API-Version: 2.11"
 </pre>
 
-### Response ###
+### Response
 
-| Status Code  | Description  |
+| Status Code | Description |
 |---|---|
-| 200 OK  | Binding was deleted. The expected response body is <code>{}</code>.  |
-| 410 Gone  | MUST be returned if the binding does not exist. The expected response body is <code>{}</code>.  |
+| 200 OK | Binding was deleted. The expected response body is <code>{}</code>. |
+| 202 Accepted | Service instance unbinding is in progress. This triggers the platform marketplace to poll the [Last Service Binding Operation Endpoint](#polling-last-service-binding-operation) for operation status. |
+| 410 Gone | SHOULD be returned if the binding does not exist. The expected response body is <code>{}</code>. |
+| 422 Unprocessable Entity | SHOULD be returned if the broker only supports asynchronous unbinding for the requested plan and the request did not include <code>?accepts_incomplete=true</code>; in this case the expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code> |
 
 Responses with any other status code will be interpreted as a failure and the binding will remain in the marketplace database. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
-##### Body #####
+##### Body
 
 All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
 
-For a success response, the expected response body is `{}`.
+For success responses, the following fields are supported. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
+
+|  Response field | Type | Description |
+|---|---|---|
+| operation | string | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field SHOULD be provided by the platform with requests to the [Last Service Binding Operation](#polling-last-service-binding-operation) endpoint in a URL encoded query parameter. |
+
+<pre class="terminal">
+{
+ "operation": "task_10"
+}
+</pre>
+
 
 ## Deprovisioning
 
@@ -691,14 +759,14 @@ delete any resources it created during the provision.
 Usually this means that all resources are immediately reclaimed for future
 provisions.
 
-### Request ###
+### Request
 
-##### Route #####
+##### Route
 `DELETE /v2/service_instances/:instance_id`
 
 `:instance_id` is the identifier of a previously provisioned instance.
 
-##### Parameters #####
+##### Parameters
 
 The request provides these query string parameters as useful hints for brokers.
 
@@ -706,28 +774,28 @@ The request provides these query string parameters as useful hints for brokers.
 |---|---|---|
 | service_id* | string | ID of the service from the catalog. |
 | plan_id* | string | ID of the plan from the catalog. |
-| accepts_incomplete  | boolean | A value of true indicates that both the marketplace and the requesting client support asynchronous deprovisioning. If this parameter is not included in the request, and the broker can only deprovision an instance of the requested plan asynchronously, the broker MUST reject the request with a 422 as described below. |
+| accepts_incomplete | boolean | A value of true indicates that both the marketplace and the requesting client support asynchronous deprovisioning. If this parameter is not included in the request, and the broker can only deprovision an instance of the requested plan asynchronously, the broker MUST reject the request with a 422 as described below. |
 
 \* Query parameters with an asterisk are REQUIRED.
 
-##### cURL #####
+##### cURL
 <pre class="terminal">
 $ curl 'http://username:password@broker-url/v2/service_instances/:instance_id?accepts_incomplete=true
   &service_id=service-id-here&plan_id=plan-id-here' -X DELETE -H "X-Broker-API-Version: 2.11"
 </pre>
 
-### Response ###
+### Response
 
 | Status Code | Description |
 |---|---|
 | 200 OK | Service instance was deleted. The expected response body is <code>{}</code>. |
-| 202 Accepted | Service instance deletion is in progress. This triggers the marketplace to poll the [Service Instance Last Operation Endpoint](#polling) for operation status.  |
-| 410 Gone | MUST be returned if the service instance does not exist. The expected response body is <code>{}</code>.  |
-| 422 Unprocessable Entity | MUST be returned if the broker only supports asynchronous deprovisioning for the requested plan and the request did not include <code>?accepts_incomplete=true</code>. The expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code>, as described below.  |
+| 202 Accepted | Service instance deletion is in progress. This triggers the marketplace to poll the [Last Service Instance Operation](#polling-last-service-instance-operation) for operation status. |
+| 410 Gone | MUST be returned if the service instance does not exist. The expected response body is <code>{}</code>. |
+| 422 Unprocessable Entity | MUST be returned if the broker only supports asynchronous deprovisioning for the requested plan and the request did not include <code>?accepts_incomplete=true</code>. The expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code>, as described below. |
 
 Responses with any other status code will be interpreted as a failure and the service instance will remain in the marketplace database. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
-##### Body #####
+##### Body
 
 All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
 
@@ -736,7 +804,7 @@ For success responses, the following fields are supported. Others will be ignore
 
 |  Response field | Type | Description |
 |---|---|---|
-| operation  | string  | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field SHOULD be provided by the broker client with requests to the [Last Operation](#polling) endpoint in a URL encoded query parameter. |
+| operation | string | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field SHOULD be provided by the broker client with requests to the [Last Service Instance Operation](#polling-last-service-instance-operation) endpoint in a URL encoded query parameter. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -748,13 +816,13 @@ For success responses, the following fields are supported. Others will be ignore
 
 ## Broker Errors
 
-### Response ###
+### Response
 
 Broker failures beyond the scope of the well-defined HTTP response codes listed
 above (like 410 on delete) MUST return an appropriate HTTP response code
 (chosen to accurately reflect the nature of the failure) and a body containing a valid JSON Object (not an array).
 
-##### Body #####
+##### Body
 
 All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
 


### PR DESCRIPTION
Binding to an instance may encapsulate a long running workflow, similar to provisioning. Discussions in issue #137 have resulted in:
* Changing the **Binding** endpoint to support asynchronous operations.
* Adding a new `last_operation` endpoint for bindings (`GET /v2/service_instances/:instance_id/service_bindings/:binding_id/last_operation`)

Feedback welcome as always.