### PR TITLE
Use RFC2119 keywords - first of many

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,8 +1,11 @@
-# Table of Contents
+# Open Service Broker API
+
+## Table of Contents
+  - [API Overview](#api-overview)
+  - [Notational Conventions](#notational-conventions)
   - [Changes](#changes)
     - [Change Policy](#change-policy)
     - [Changes Since v2.10](#changes-since-v210)
-  - [API Overview](#api-overview)
   - [API Version Header](#api-version-header)
   - [Authentication](#authentication)
   - [Catalog Management](#catalog-management)
@@ -21,22 +24,7 @@
   - [Broker Errors](#broker-errors)
   - [Orphans](#orphans)
 
-## Changes
-
-### Change Policy 
-
-* Existing endpoints and fields will not be removed or renamed.
-* New optional endpoints, or new HTTP methods for existing endpoints, may be
-added to enable support for new features.
-* New fields may be added to existing request/response messages.
-These fields must be optional and should be ignored by clients and servers
-that do not understand them.
-
-## Changes Since v2.10
-
-* Add <tt>bindable</tt> field to [Plan Object](#PObject) to allow services to have both bindable and non-bindable plans.
-
-## API Overview 
+## API Overview
 
 The Service Broker API defines an HTTP interface between the services marketplace of a platform and service brokers.
 
@@ -44,34 +32,55 @@ The service broker is the component of the service that implements the Service B
 
 In general, provisioning reserves a resource on a service; we call this reserved resource a service instance. What a service instance represents can vary by service. Examples include a single database on a multi-tenant server, a dedicated cluster, or an account on a web application.
 
-What a binding represents may also vary by service. In general creation of a binding either generates credentials necessary for accessing the resource or provides the service instance with information for a configuration change.
+What a binding represents MAY also vary by service. In general creation of a binding either generates credentials necessary for accessing the resource or provides the service instance with information for a configuration change.
 
-A platform marketplace may expose services from one or many service brokers, and an individual service broker may support one or many platform marketplaces using different URL prefixes and credentials.
+A platform marketplace MAY expose services from one or many service brokers, and an individual service broker MAY support one or many platform marketplaces using different URL prefixes and credentials.
+
+## Notational Conventions
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this document are to
+be interpreted as described in [RFC 2119]( https://tools.ietf.org/html/rfc2119).
+
+## Changes
+
+### Change Policy
+
+* Existing endpoints and fields MUST NOT be removed or renamed.
+* New OPTIONAL endpoints, or new HTTP methods for existing endpoints, MAY be
+added to enable support for new features.
+* New fields MAY be added to existing request/response messages.
+These fields MUST be OPTIONAL and SHOULD be ignored by clients and servers
+that do not understand them.
+
+### Changes Since v2.10
+
+* Add <tt>bindable</tt> field to [Plan Object](#PObject) to allow services to have both bindable and non-bindable plans.
 
 ## API Version Header
 
-Requests from the platform to the service broker must contain a header that declares the version number of the Service Broker API that the marketplace will use:
+Requests from the platform to the service broker MUST contain a header that declares the version number of the Service Broker API that the marketplace will use:
 
 `X-Broker-Api-Version: 2.11`
 
 The version numbers are in the format `MAJOR.MINOR`, using semantic versioning such that 2.10 comes before 2.11.
 
-This header allows brokers to reject requests from marketplaces for versions they do not support. While minor API revisions will always be additive, it is possible that brokers depend on a feature from a newer version of the API that is supported by the platform. In this scenario the broker may reject the request with `412 Precondition Failed` and provide a message that informs the operator of the required API version.
+This header allows brokers to reject requests from marketplaces for versions they do not support. While minor API revisions will always be additive, it is possible that brokers depend on a feature from a newer version of the API that is supported by the platform. In this scenario the broker MAY reject the request with `412 Precondition Failed` and provide a message that informs the operator of the API version that is to be used instead.
 
 ## Authentication
 
-The marketplace must authenticate with the service broker using HTTP
-basic authentication (the `Authorization:` header) on every request. The broker is responsible for validating the username and password and returning a `401 Unauthorized` message if credentials are invalid. It is recommended that brokers support secure communication from platform marketplaces over TLS.
+The marketplace MUST authenticate with the service broker using HTTP
+basic authentication (the `Authorization:` header) on every request. The broker is responsible for validating the username and password and returning a `401 Unauthorized` message if credentials are invalid. It is RECOMMENDED that brokers support secure communication from platform marketplaces over TLS.
 
-## Catalog Management 
+## Catalog Management
 
-The first endpoint that a broker must implement is the service catalog.
+The first endpoint that a platform will interact with on the broker is the service catalog.
 
 The platform marketplace fetches this endpoint from all brokers in order to present an aggregated user-facing catalog.
 
 Warnings for broker authors:
 
-- Be cautious removing services and plans from their catalogs, as platform marketplaces may have provisioned service instances of these plans. Consider your deprecation strategy.
+- Be cautious removing services and plans from their catalogs, as platform marketplaces might have provisioned service instances of these plans. Consider your deprecation strategy.
 - Do not change the ids of services and plans. This action is likely to be evaluated by a platform marketplace as a removal of one plan and addition of another. See above warning about removal of plans.
 
 The following sections describe catalog requests and responses in the Service Broker API.
@@ -108,8 +117,8 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
 
 |  Response field |  Type | Description  |
 |---|---|---|
-|  name* | string  |  A CLI-friendly name of the service. All lowercase, no spaces. This must be globally unique within a platform marketplace. |
-| id*  |  string | An identifier used to correlate this service in future requests to the broker. This must be globally unique within a platform marketplace. Using a GUID is recommended.  |
+|  name* | string  |  A CLI-friendly name of the service. All lowercase, no spaces. This MUST be globally unique within a platform marketplace. |
+| id*  |  string | An identifier used to correlate this service in future requests to the broker. This MUST be globally unique within a platform marketplace. Using a GUID is RECOMMENDED.  |
 |  description* |  string | A short description of the service.  |
 | tags  |  array-of-strings | Tags provide a flexible mechanism to expose a classification, attribute, or base technology of a service, enabling equivalent services to be swapped out without changes to dependent logic in applications, buildpacks, or other services. E.g. mysql, relational, redis, key-value, caching, messaging, amqp.  |
 |  requires | array-of-strings  | A list of permissions that the user would have to give the service, if they provision it. The only permissions currently supported are <code>syslog\_drain</code>, <code>route\_forwarding</code> and <code>volume\_mount</code>.  |
@@ -132,15 +141,15 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
 
 |  Response field | Type  | Description  |
 |---|---|---|
-| id*  | string  | An identifier used to correlate this plan in future requests to the broker. This must be globally unique within a platform marketplace. Using a GUID is recommended.  |
-| name*  | string  | The CLI-friendly name of the plan. Must be unique within the service. All lowercase, no spaces.  |
+| id*  | string  | An identifier used to correlate this plan in future requests to the broker. This MUST be globally unique within a platform marketplace. Using a GUID is RECOMMENDED.  |
+| name*  | string  | The CLI-friendly name of the plan. MUST be unique within the service. All lowercase, no spaces.  |
 | description*  | string  | A short description of the plan.  |
 |  metadata | JSON object  | An opaque object of metadata for a service plan. Controller treats this as a blob. Note that there are (conventions)[https://docs.cloudfoundry.org/services/catalog-metadata.html] in existing brokers and controllers for fields that aid in the display of catalog data. |
 | free  | boolean  | When false, instances of this plan have a cost. The default is true  |
-|  bindable | boolean  |  Specifies whether instances of the service plan can be bound to applications. This field is optional. If specified, this takes precedence over the <tt>bindable</tt> attribute of the service. If not specified, the default is derived from the service. |
+|  bindable | boolean  |  Specifies whether instances of the service plan can be bound to applications. This field is OPTIONAL. If specified, this takes precedence over the <tt>bindable</tt> attribute of the service. If not specified, the default is derived from the service. |
 
 
-\* Fields with an asterisk are required.
+\* Fields with an asterisk are REQUIRED.
 
 <pre>
 {
@@ -224,29 +233,29 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
 </pre>
 
 
-### Adding a Broker to the Platform 
+### Adding a Broker to the Platform
 
-After implementing the first endpoint `GET /v2/catalog` documented [above](#catalog-mgmt), you must register the service broker with your platform to make your services and plans available to end users.
+After implementing the first endpoint `GET /v2/catalog` documented [above](#catalog-mgmt), the service broker will need to be registered with your platform to make your services and plans available to end users.
 
-## Synchronous and Asynchronous Operations 
+## Synchronous and Asynchronous Operations
 
-Broker clients expect prompt responses to all API requests in order to provide users with fast feedback. Service broker authors should implement their brokers to respond promptly to all requests but must decide whether to implement synchronous or asynchronous responses. Brokers that can guarantee completion of the requested operation with the response should return the synchronous response. Brokers that cannot guarantee completion of the operation with the response should implement the asynchronous response.
+Broker clients expect prompt responses to all API requests in order to provide users with fast feedback. Service broker authors SHOULD implement their brokers to respond promptly to all requests but will need to decide whether to implement synchronous or asynchronous responses. Brokers that can guarantee completion of the requested operation with the response SHOULD return the synchronous response. Brokers that cannot guarantee completion of the operation with the response SHOULD implement the asynchronous response.
 
-Providing a synchronous response for a provision, update, or bind operation before actual completion causes confusion for users as their service may not be usable and they have no way to find out when it will be. Asynchronous responses set expectations for users that an operation is in progress and can also provide updates on the status of the operation.
+Providing a synchronous response for a provision, update, or bind operation before actual completion causes confusion for users as their service might not be usable and they have no way to find out when it will be. Asynchronous responses set expectations for users that an operation is in progress and can also provide updates on the status of the operation.
 
-Support for synchronous or asynchronous responses may vary by service offering, even by service plan.
+Support for synchronous or asynchronous responses MAY vary by service offering, even by service plan.
 
-### Synchronous Operations 
+### Synchronous Operations
 
 To execute a request synchronously, the broker need only return the usual status codes: `201 CREATED` for provision and bind, and `200 OK` for update, unbind, and deprovision.
 
 Brokers that support sychronous responses for provision, update, and delete can ignore the `accepts_incomplete=true` query parameter if it is provided by the client.
 
-### Asynchronous Operations 
+### Asynchronous Operations
 
 <p class='note'><strong>Note:</strong> Asynchronous operations are currently supported only for provision, update, and deprovision.</p>
 
-For a broker to return an asynchronous response, the query parameter `accepts_incomplete=true` must be included the request. If the parameter is not included or is set to `false`, and the broker cannot fulfill the request synchronously (guaranteeing that the operation is complete on response), then the broker should reject the request with the status code `422 UNPROCESSABLE ENTITY` and the following body:
+For a broker to return an asynchronous response, the query parameter `accepts_incomplete=true` MUST be included the request. If the parameter is not included or is set to `false`, and the broker cannot fulfill the request synchronously (guaranteeing that the operation is complete on response), then the broker SHOULD reject the request with the status code `422 UNPROCESSABLE ENTITY` and the following body:
 
 <pre class="terminal">
 {
@@ -255,17 +264,17 @@ For a broker to return an asynchronous response, the query parameter `accepts_in
 }
 </pre>
 
-If the query parameter described above is present, and the broker executes the request asynchronously, the broker must return the asynchronous response `202 ACCEPTED`. The response body should be the same as if the broker were serving the request synchronously.
+If the query parameter described above is present, and the broker executes the request asynchronously, the broker MUST return the asynchronous response `202 ACCEPTED`. The response body SHOULD be the same as if the broker were serving the request synchronously.
 
-An asynchronous response triggers the platform marketplace to poll the endpoint `GET /v2/service_instances/:guid/last_operation` until the broker indicates that the requested operation has succeeded or failed. Brokers may include a status message with each response for the `last_operation` endpoint that provides visibility to end users as to the progress of the operation.
+An asynchronous response triggers the platform marketplace to poll the endpoint `GET /v2/service_instances/:guid/last_operation` until the broker indicates that the requested operation has succeeded or failed. Brokers MAY include a status message with each response for the `last_operation` endpoint that provides visibility to end users as to the progress of the operation.
 
 #### Blocking Operations ####
 
-The marketplace must ensure that service brokers do not receive requests for an instance while an asynchronous operation is in progress. For example, if a broker is in the process of provisioning an instance asynchronously, the marketplace must not allow any update, bind, unbind, or deprovision requests to be made through the platform. A user who attempts to perform one of these actions while an operation is already in progress must receive an HTTP 400 response with the error message: `Another operation for this service instance is in progress`.
+The marketplace MUST ensure that service brokers do not receive requests for an instance while an asynchronous operation is in progress. For example, if a broker is in the process of provisioning an instance asynchronously, the marketplace can not allow any update, bind, unbind, or deprovision requests to be made through the platform. A user who attempts to perform one of these actions while an operation is already in progress MUST receive an HTTP 400 response with the error message: `Another operation for this service instance is in progress`.
 
-## Polling Last Operation 
+## Polling Last Operation
 
-When a broker returns status code `202 ACCEPTED` for [provision](#provisioning), [update](#updating_service_instance), or [deprovision](#deprovisioning), the platform will begin polling the `/v2/service_instances/:guid/last_operation` endpoint to obtain the state of the last requested operation. The broker response must contain the field `state` and an optional field `description`.
+When a broker returns status code `202 ACCEPTED` for [provision](#provisioning), [update](#updating_service_instance), or [deprovision](#deprovisioning), the platform will begin polling the `/v2/service_instances/:guid/last_operation` endpoint to obtain the state of the last requested operation. The broker response MUST contain the field `state` and MAY contain the field `description`.
 
 Valid values for `state` are `in progress`, `succeeded`, and `failed`. The platform will poll the `last_operation` endpoint as long as the broker returns `"state": "in progress"`. Returning `"state": "succeeded"` or `"state": "failed"` will cause the platform to cease polling. The value provided for `description` will be passed through to the platform API client and can be used to provide additional detail for users about the progress of the operation.
 
@@ -282,9 +291,9 @@ The request provides these query string parameters as useful hints for brokers.
 |---|---|---|
 | service_id  |  string | ID of the service from the catalog.  |
 | plan_id  | string  | ID of the plan from the catalog.  |
-| operation  |  string | A broker-provided identifier for the operation. When a value for <code>operation</code> is included with asynchronous responses for [Provision](#provisioning), [Update](#updating_service_instance), and [Deprovision](#deprovisioning) requests, the broker client should provide the same value using this query parameter as a URL-encoded string.  |
+| operation  |  string | A broker-provided identifier for the operation. When a value for <code>operation</code> is included with asynchronous responses for [Provision](#provisioning), [Update](#updating_service_instance), and [Deprovision](#deprovisioning) requests, the broker client SHOULD provide the same value using this query parameter as a URL-encoded string.  |
 
-<p class="note"><strong>Note:</strong> Although the request query parameters <code>service_id</code> and <code>plan_id</code> are not required, the platform should include them on all <code>last_operation</code> requests it makes to service brokers.</p>
+<p class="note"><strong>Note:</strong> Although the request query parameters <code>service_id</code> and <code>plan_id</code> are not mandatory, the platform SHOULD include them on all <code>last_operation</code> requests it makes to service brokers.</p>
 
 ##### cURL #####
 <pre class="terminal">
@@ -296,22 +305,22 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id/las
 | Status Code  |  Description |
 |---|---|
 | 200 OK |  The expected response body is below. |
-|  410 GONE | Appropriate only for asynchronous delete operations. The platform should consider this response a success and remove the resource from its database. The expected response body is <code>{}</code>. Returning this while the platform is polling for create or update operations should be interpreted as an invalid response and the platform should continue polling.  |
+|  410 GONE | Appropriate only for asynchronous delete operations. The platform MUST consider this response a success and remove the resource from its database. The expected response body is <code>{}</code>. Returning this while the platform is polling for create or update operations SHOULD be interpreted as an invalid response and the platform SHOULD continue polling.  |
 
-Responses with any other status code should be interpreted as an error or invalid response. The platform should continue polling until the broker returns a valid response or the [maximum polling duration](#polling-interval-and-duration) is reached. Brokers may use the `description` field to expose user-facing error messages about the operation state; for more info see [Broker Errors](#broker-errors).
+Responses with any other status code SHOULD be interpreted as an error or invalid response. The platform SHOULD continue polling until the broker returns a valid response or the [maximum polling duration](#polling-interval-and-duration) is reached. Brokers MAY use the `description` field to expose user-facing error messages about the operation state; for more info see [Broker Errors](#broker-errors).
 
 ##### Body #####
 
-All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
 
 For success responses, the following fields are valid.
 
 |  Response field | Type  | Description  |
 |---|---|---|
-| state*  | string  | Valid values are <code>in progress</code>, <code>succeeded</code>, and <code>failed</code>. While <code>"state": "in progress"</code>, the platform should continue polling. A response with <code>"state": "succeeded"</code> or <code>"state": "failed"</code> should cause the platform to cease polling.  |
-|  description |  string | Optional field. A user-facing message displayed to the platform API client. Can be used to tell the user details about the status of the operation.  |
+| state*  | string  | Valid values are <code>in progress</code>, <code>succeeded</code>, and <code>failed</code>. While <code>"state": "in progress"</code>, the platform SHOULD continue polling. A response with <code>"state": "succeeded"</code> or <code>"state": "failed"</code> MUST cause the platform to cease polling.  |
+|  description |  string | OPTIONAL field. A user-facing message displayed to the platform API client. Can be used to tell the user details about the status of the operation.  |
 
-\* Fields with an asterisk are required.
+\* Fields with an asterisk are REQUIRED.
 
 <pre class="terminal">
 {
@@ -320,20 +329,20 @@ For success responses, the following fields are valid.
 }
 </pre>
 
-### Polling Interval and Duration    
+### Polling Interval and Duration
 
-The frequency and maximum duration of polling may vary by platform client. If a platform has a max polling duration and this limit is reached, the platform will cease polling and the operation state will be considered `failed`.
+The frequency and maximum duration of polling MAY vary by platform client. If a platform has a max polling duration and this limit is reached, the platform MUST cease polling and the operation state MUST be considered `failed`.
 
 ## Provisioning
 
-When the broker receives a provision request from the platform, it should take whatever action is necessary to create a new resource. What provisioning represents varies by service and plan, although there are several common use cases. For a MySQL service, provisioning could result in an empty dedicated database server running on its own VM or an empty schema on a shared database server. For non-data services, provisioning could just mean an account on an multi-tenant SaaS application.
+When the broker receives a provision request from the platform, it MUST take whatever action is necessary to create a new resource. What provisioning represents varies by service and plan, although there are several common use cases. For a MySQL service, provisioning could result in an empty dedicated database server running on its own VM or an empty schema on a shared database server. For non-data services, provisioning could just mean an account on an multi-tenant SaaS application.
 
 ### Request ###
 
 ##### Route #####
 `PUT /v2/service_instances/:instance_id`
 
-The `:instance_id` of a service instance is provided by the platform. This ID will be used for future requests (bind and deprovision), so the broker must use it to correlate the resource it creates.
+The `:instance_id` of a service instance is provided by the platform. This ID will be used for future requests (bind and deprovision), so the broker will use it to correlate the resource it creates.
 
 #### Parameters ####
 | Parameter name  | Type  |  Description |
@@ -344,13 +353,13 @@ The `:instance_id` of a service instance is provided by the platform. This ID wi
 ##### Body #####
 | Request field  | Type  |  Description |
 |---|---|---|
-| service_id*  | string  | The ID of the service (from the catalog). Must be globally unique.  |
-| plan_id*  | string  | The ID of the plan (from the catalog) for which the service instance has been requested. Must be unique to a service.  |
-| organization_guid*  | string  | The platform GUID for the organization under which the service is to be provisioned. Although most brokers will not use this field, it may be helpful for executing operations on a user's behalf.  |
-|  space_guid* |  string |  The identifier for the project space within the platform organization. Although most brokers will not use this field, it may be helpful for executing operations on a user's behalf. |
-|  parameters |  JSON object | Configuration options for the service instance.  |
+| service_id*  | string  | The ID of the service (from the catalog). MUST be globally unique.  |
+| plan_id*  | string  | The ID of the plan (from the catalog) for which the service instance has been requested. MUST be unique to a service.  |
+| organization_guid*  | string  | The platform GUID for the organization under which the service is to be provisioned. Although most brokers will not use this field, it might be helpful for executing operations on a user's behalf.  |
+|  space_guid* |  string |  The identifier for the project space within the platform organization. Although most brokers will not use this field, it might be helpful for executing operations on a user's behalf. |
+|  parameters |  JSON object | Configuration options for the service instance. Controller treats this as a blob. Note that there are (conventions)[https://docs.cloudfoundry.org/services/catalog-metadata.html] in existing brokers and controllers for fields that aid in the display of catalog data. |
 
-\* Fields with an asterisk are required.
+\* Fields with an asterisk are REQUIRED.
 
 <pre class="terminal">
 {
@@ -384,26 +393,26 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id?acc
 | Status Code  | Description  |
 |---|---|
 | 201 Created  | Service instance has been provisioned. The expected response body is below.  |
-| 200 OK  |  May be returned if the service instance already exists and the requested parameters are identical to the existing service instance. The expected response body is below. |
+| 200 OK  |  MAY be returned if the service instance already exists and the requested parameters are identical to the existing service instance. The expected response body is below. |
 | 202 Accepted  | Service instance provisioning is in progress. This triggers the platform marketplace to poll the [Service Instance Last Operation Endpoint](#polling) for operation status.  |
-| 409 Conflict  | Should be returned if a service instance with the same id already exists but with different attributes. The expected response body is <code>{}</code>.  |
-| 422 Unprocessable Entity  | Should be returned if the broker only supports asynchronous provisioning for the requested plan and the request did not include <code>?accepts_incomplete=true</code>. The expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code>, as described below.  |
+| 409 Conflict  | MUST be returned if a service instance with the same id already exists but with different attributes. The expected response body is <code>{}</code>.  |
+| 422 Unprocessable Entity  | MUST be returned if the broker only supports asynchronous provisioning for the requested plan and the request did not include <code>?accepts_incomplete=true</code>. The expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code>, as described below.  |
 
 
 Responses with any other status code will be interpreted as a failure. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
 ##### Body #####
 
-All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
 
-For success responses, a broker may return the following fields. For error responses, see [Broker Errors](#broker-errors).
+For success responses, a broker MUST return the following fields. For error responses, see [Broker Errors](#broker-errors).
 
 | Response field  |  Type | Description  |
 |---|---|---|
-|  dashboard_url | string  |  The URL of a web-based management user interface for the service instance; we refer to this as a service dashboard. The URL should contain enough information for the dashboard to identify the resource being accessed (<code>9189kdfsk0vfnku</code> in the example below).  Note: a broker that wishes to return `dashboard_url` for a service instance must return it with the initial response to the provision request, even if the service is provisioned asynchronously. |
-|  operation |  string | For asynchronous responses, service brokers may return an identifier representing the operation. The value of this field should be provided by the broker client with requests to the [Last Operation](#polling) endpoint in a URL encoded query parameter.  |
+|  dashboard_url | string  |  The URL of a web-based management user interface for the service instance; we refer to this as a service dashboard. The URL MUST contain enough information for the dashboard to identify the resource being accessed (<code>9189kdfsk0vfnku</code> in the example below).  Note: a broker that wishes to return `dashboard_url` for a service instance MUST return it with the initial response to the provision request, even if the service is provisioned asynchronously. |
+|  operation |  string | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field SHOULD be provided by the broker client with requests to the [Last Operation](#polling) endpoint in a URL encoded query parameter.  |
 
-\* Fields with an asterisk are required.
+\* Fields with an asterisk are REQUIRED.
 
 <pre class="terminal">
 {
@@ -412,13 +421,13 @@ For success responses, a broker may return the following fields. For error respo
 }
 </pre>
 
-## Updating a Service Instance 
+## Updating a Service Instance
 
 By implementing this endpoint, service broker authors can enable users to modify two attributes of an existing service instance: the service plan and parameters. By changing the service plan, users can upgrade or downgrade their service instance to other plans. By modifying properties, users can change configuration options that are specific to a service or plan.
 
-To enable support for the update of the plan, a broker should declare support per service by including `plan_updateable: true` in its [catalog endpoint](#catalog-mgmt).
+To enable support for the update of the plan, a broker MUST declare support per service by including `plan_updateable: true` in its [catalog endpoint](#catalog-mgmt).
 
-Not all permutations of plan changes are expected to be supported. For example, a service may support upgrading from plan "shared small" to "shared large" but not to plan "dedicated". It is up to the broker to validate whether a particular permutation of plan change is supported. If a particular plan change is not supported, the broker should return a meaningful error message in response.
+Not all permutations of plan changes are expected to be supported. For example, a service might support upgrading from plan "shared small" to "shared large" but not to plan "dedicated". It is up to the broker to validate whether a particular permutation of plan change is supported. If a particular plan change is not supported, the broker SHOULD return a meaningful error message in response.
 
 ### Request ###
 
@@ -436,16 +445,16 @@ Not all permutations of plan changes are expected to be supported. For example, 
 
 | Request Field  | Type  |  Description |
 |---|---|---|
-| service\_id*  | string  | The ID of the service (from the catalog). Must be globally unique.  |
-| plan\_id  | string  | The ID of the plan (from the catalog) for which the service instance has been requested. Must be unique to a service.  |
-| parameters  | JSON object  | Configuration options for the service instance.  |
+| service\_id*  | string  | The ID of the service (from the catalog). MUST be globally unique.  |
+| plan\_id  | string  | The ID of the plan (from the catalog) for which the service instance has been requested. MUST be unique to a service.  |
+| parameters  | JSON object  | Configuration options for the service instance. An opaque object, controller treats this as a blob. |
 | previous\_values  | object  |  Information about the instance prior to the update. |
 | previous\_values.service_id  | string  | ID of the service for the instance.  |
 | previous\_values.plan_id  |  string | ID of the plan prior to the update.  |
 | previous\_values.organization_id  | string  | ID of the organization specified for the instance.  |
 | previous\_values.space_id  | string  | ID of the space specified for the instance.  |
 
-\* Fields with an asterisk are required.
+\* Fields with an asterisk are REQUIRED.
 
 <pre class="terminal">
 {
@@ -488,21 +497,21 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id?acc
 |---|---|
 | 200 OK  | The requests changes have been applied. The expected response body is <code>{}</code>.  |
 | 202 Accepted  |  Service instance update is in progress. This triggers the platform marketplace to poll the [Service Instance Last Operation Endpoint](#polling) for operation status. |
-| 422 Unprocessable entity  | May be returned if the requested change is not supported or if the request cannot currently be fulfilled due to the state of the instance (e.g. instance utilization is over the quota of the requested plan). Broker should include a user-facing message in the body; for details see [Broker Errors](#broker-errors).  Additionally, a 422 can also be returned if the broker only supports asynchronous update for the requested plan and the request did not include <code>?accepts_incomplete=true</code>; in this case the expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code>  |
+| 422 Unprocessable entity  | MUST be returned if the requested change is not supported or if the request cannot currently be fulfilled due to the state of the instance (e.g. instance utilization is over the quota of the requested plan). Broker SHOULD include a user-facing message in the body; for details see [Broker Errors](#broker-errors).  Additionally, a 422 can also be returned if the broker only supports asynchronous update for the requested plan and the request did not include <code>?accepts_incomplete=true</code>; in this case the expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code>  |
 
 Responses with any other status code will be interpreted as a failure. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
 ##### Body #####
 
-All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
 
-For success responses, a broker may return the following field. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
+For success responses, a broker MUST return the following field. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
 
 | Response field  | Type  | Description  |
 |---|---|---|
-| operation  | string  |  For asynchronous responses, service brokers may return an identifier representing the operation. The value of this field should be provided by the broker client with requests to the [Last Operation](#polling) endpoint in a URL encoded query parameter. |
+| operation  | string  |  For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field SHOULD be provided by the broker client with requests to the [Last Operation](#polling) endpoint in a URL encoded query parameter. |
 
-\* Fields with an asterisk are required.
+\* Fields with an asterisk are REQUIRED.
 
 <pre class="terminal">
 {
@@ -511,44 +520,44 @@ For success responses, a broker may return the following field. Others will be i
 </pre>
 
 
-## Binding 
+## Binding
 
-If `bindable:true` is declared for a service or plan in the [Catalog](#catalog-mgmt) endpoint, broker clients may request generation of a service binding. 
+If `bindable:true` is declared for a service or plan in the [Catalog](#catalog-mgmt) endpoint, broker clients MAY request generation of a service binding.
 
-<p class="note"><strong>Note</strong>: Not all services must be bindable --- some deliver value just from being provisioned. Brokers that offer services that are bindable should declare them as such using <code>bindable: true</code> in the <a href="#catalog-mgmt">Catalog</a>. Brokers that do not offer any bindable services do not need to implement the endpoint for bind requests.</p>
+<p class="note"><strong>Note</strong>: Not all services need to be bindable --- some deliver value just from being provisioned. Brokers that offer services that are bindable MUST declare them as such using <code>bindable: true</code> in the <a href="#catalog-mgmt">Catalog</a>. Brokers that do not offer any bindable services do not need to implement the endpoint for bind requests.</p>
 
-### Types of Binding 
+### Types of Binding
 
 #### Credentials ####
 
-Credentials are a set of information used by an application or a user to utilize the service instance. If the broker supports generation of credentials it should return `credentials` in the response for a request to create a service binding. Credentials should be unique whenever possible, so access can be revoked for each binding without affecting consumers of other bindings for the service instance. 
+Credentials are a set of information used by an application or a user to utilize the service instance. If the broker supports generation of credentials it MUST return `credentials` in the response for a request to create a service binding. Credentials SHOULD be unique whenever possible, so access can be revoked for each binding without affecting consumers of other bindings for the service instance.
 
 #### Log Drain ####
 
-There are a class of service offerings that provide aggregation, indexing, and analysis of log data. To utilize these services an application that generates logs needs information for the location to which it should stream logs. If a broker represents one of these services, it may optionally return a `syslog_drain_url` in the response for a request to create a service binding, to which logs may be streamed.  
+There are a class of service offerings that provide aggregation, indexing, and analysis of log data. To utilize these services an application that generates logs needs information for the location to which it will stream logs. If a broker represents one of these services, it MAY return a `syslog_drain_url` in the response for a request to create a service binding, to which logs MUST be streamed.
 
-The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate a response for create binding that includes a `syslog_drain_url`. Platform marketplaces should consider a broker's response invalid if it includes a `syslog_drain_url` and `"requires":["syslog_drain"]` is not present in the [Catalog](#catalog-mgmt) endpoint.
+The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate a response for create binding that includes a `syslog_drain_url`. Platform marketplaces can consider a broker's response invalid if it includes a `syslog_drain_url` and `"requires":["syslog_drain"]` is not present in the [Catalog](#catalog-mgmt) endpoint.
 
-#### Route Services 
+#### Route Services
 
-There are a class of service offerings that intermediate requests to applications, performing functions such as rate limiting or authorization. To configure a service instance with behavior specific to an application's routable address, a broker client may send the address along with the request to create a binding using `"bind_resource":{"route":"some-address.com"}`.
+There are a class of service offerings that intermediate requests to applications, performing functions such as rate limiting or authorization. To configure a service instance with behavior specific to an application's routable address, a broker client MAY send the address along with the request to create a binding using `"bind_resource":{"route":"some-address.com"}`.
 
-Some platforms may support proxying of application requests to service instances. In this case the platform needs to know where to send application requests; to facilitate this, the broker may return a `route_service_url` in the response for a request to create a binding. Not all services of this type expect to receive requests proxied by the platform; some services will have been configured out-of-band to intermediate requests to applications. In this case, the broker will not return `route_service_url` in response to the create binding request. By sending `bind-resource` as described above, the platform enables dynamic configuration of a service instance already in the application request path for the route, requiring no change in the platform routing tier. 
+Some platforms MAY support proxying of application requests to service instances. In this case the platform needs to know where to send application requests; to facilitate this, the broker MUST return a `route_service_url` in the response for a request to create a binding. Not all services of this type expect to receive requests proxied by the platform; some services will have been configured out-of-band to intermediate requests to applications. In this case, the broker will not return `route_service_url` in response to the create binding request. By sending `bind-resource` as described above, the platform enables dynamic configuration of a service instance already in the application request path for the route, requiring no change in the platform routing tier.
 
-The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate requests to create bindings. A platform may opt to reject requests to create bindings when a broker has declared `"requires":["route_forwarding"]` for a service in the catalog endpoint.
+The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate requests to create bindings. A platform MAY reject requests to create bindings when a broker has declared `"requires":["route_forwarding"]` for a service in the catalog endpoint.
 
 #### Volume Services ####
 
-There are a class of services that provide network storage to applications via volume mounts in the application container. A service broker may return data required for this configuration with `volume_mount` in response to the request to create a binding. 
+There are a class of services that provide network storage to applications via volume mounts in the application container. A service broker MUST return data needed for this configuration with `volume_mount` in response to the request to create a binding.
 
-The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate a response for create binding that includes a `volume_mounts`. Platform marketplaces should consider a broker's response invalid if it includes a `volume_mounts` and `"requires":["volume_mount"]` is not present in the [Catalog](#catalog-mgmt) endpoint.
+The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate a response for create binding that includes a `volume_mounts`. Platform marketplaces can consider a broker's response invalid if it includes a `volume_mounts` and `"requires":["volume_mount"]` is not present in the [Catalog](#catalog-mgmt) endpoint.
 
 ### Request ###
 
 ##### Route #####
 `PUT /v2/service_instances/:instance_id/service_bindings/:binding_id`
 
-The `:instance_id` is the ID of a previously-provisioned service instance. The `:binding_id` is also provided by the platform. This ID will be used for future unbind requests, so the broker must use it to correlate
+The `:instance_id` is the ID of a previously-provisioned service instance. The `:binding_id` is also provided by the platform. This ID will be used for future unbind requests, so the broker will use it to correlate
 the resource it creates.
 
 ##### Body #####
@@ -561,7 +570,7 @@ the resource it creates.
 | bind_resource  | JSON object  | A JSON object that contains data for platform resources associated with the binding to be created. Current valid values include <code>app\_guid</code> for [credentials](#types-of-binding) and <code>route</code> for [route services](#route_services).  |
 | parameters | JSON object  |  Configuration options for the service binding. An opaque object, controller treats this as a blob.  |   |
 
-\* Fields with an asterisk are required.
+\* Fields with an asterisk are REQUIRED.
 
 <pre class="terminal">
 {
@@ -598,24 +607,24 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id/ser
 | Status Code  | Description  |
 |---|---|
 | 201 Created  |  Binding has been created. The expected response body is below. |
-| 200 OK  |  May be returned if the binding already exists and the requested parameters are identical to the existing binding. The expected response body is below. |
-| 409 Conflict  | Should be returned if the requested binding already exists. The expected response body is <code>{}</code>, though the description field can be used to return a user-facing error message, as described in [Broker Errors](#broker-errors).  |
-| 422 Unprocessable Entity  | Should be returned if the broker requires that <code>app_guid</code> be included in the request body. The expected response body is: <code>{ "error": "RequiresApp", "description": "This service supports generation of credentials through binding an application only." }</code>  |
+| 200 OK  |  MUST be returned if the binding already exists and the requested parameters are identical to the existing binding. The expected response body is below. |
+| 409 Conflict  | MUST be returned if the requested binding already exists. The expected response body is <code>{}</code>, though the description field MAY be used to return a user-facing error message, as described in [Broker Errors](#broker-errors).  |
+| 422 Unprocessable Entity  | MUST be returned if the broker requires that <code>app_guid</code> be included in the request body. The expected response body is: <code>{ "error": "RequiresApp", "description": "This service supports generation of credentials through binding an application only." }</code>  |
 
 Responses with any other status code will be interpreted as a failure and an unbind request will be sent to the broker to prevent an orphan being created on the broker. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
 ##### Body #####
 
-All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
 
 For success responses, the following fields are supported. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
 
 |  Response Field | Type  | Description  |
 |---|---|---|
-| credentials  | object  |  A free-form hash of credentials that may be used by applications or users to access the service. |
-| syslog\_drain_url  | string  | A URL to which logs may be streamed. <code>"requires":["syslog\_drain"]</code> must be declared in the [Catalog](#catalog-mgmt) endpoint or the platform should consider the response invalid.  |
-| route\_service_url  | string  |  A URL to which the platform may proxy requests for the address sent with <code>bind\_resource.route</code> in the request body. <code>"requires":["route\_forwarding"]</code> must be declared in the [Catalog](#catalog-mgmt) endpoint or the platform should consider the response invalid. |
-| volume\_mounts  | array-of-objects  | An array of configuration for mounting volumes. <code>"requires":["volume_mount"]</code> must be declared in the [Catalog](#catalog-mgmt) endpoint or the platform should consider the response invalid.  |
+| credentials  | object  |  A free-form hash of credentials that can be used by applications or users to access the service. |
+| syslog\_drain_url  | string  | A URL to which logs MUST be streamed. <code>"requires":["syslog\_drain"]</code> MUST be declared in the [Catalog](#catalog-mgmt) endpoint or the platform MUST consider the response invalid.  |
+| route\_service_url  | string  |  A URL to which the platform MUST proxy requests for the address sent with <code>bind\_resource.route</code> in the request body. <code>"requires":["route\_forwarding"]</code> MUST be declared in the [Catalog](#catalog-mgmt) endpoint or the platform can consider the response invalid. |
+| volume\_mounts  | array-of-objects  | An array of configuration for mounting volumes. <code>"requires":["volume_mount"]</code> MUST be declared in the [Catalog](#catalog-mgmt) endpoint or the platform can consider the response invalid.  |
 
 <pre class="terminal">
     {
@@ -630,11 +639,11 @@ For success responses, the following fields are supported. Others will be ignore
     }
 </pre>
 
-## Unbinding 
+## Unbinding
 
 <p class="note"><strong>Note</strong>: Brokers that do not provide any bindable services or plans do not need to implement this endpoint.</p>
 
-When a broker receives an unbind request from the marketplace, it should delete any resources associated with the binding. In the case where credentials were generated, this may result in requests to the service instance failing to authenticate.
+When a broker receives an unbind request from the marketplace, it MUST delete any resources associated with the binding. In the case where credentials were generated, this might result in requests to the service instance failing to authenticate.
 
 ### Request ###
 
@@ -652,7 +661,7 @@ The request provides these query string parameters as useful hints for brokers.
 | service_id*  | string | ID of the service from the catalog. |
 | plan_id*  | string  | ID of the plan from the catalog. |
 
-\* Query parameters with an asterisk are required.
+\* Query parameters with an asterisk are REQUIRED.
 
 ##### cURL #####
 <pre class="terminal">
@@ -665,19 +674,19 @@ $ curl 'http://username:password@broker-url/v2/service_instances/:instance_id/
 | Status Code  | Description  |
 |---|---|
 | 200 OK  | Binding was deleted. The expected response body is <code>{}</code>.  |
-| 410 Gone  | Should be returned if the binding does not exist. The expected response body is <code>{}</code>.  |
+| 410 Gone  | MUST be returned if the binding does not exist. The expected response body is <code>{}</code>.  |
 
 Responses with any other status code will be interpreted as a failure and the binding will remain in the marketplace database. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
 ##### Body #####
 
-All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
 
 For a success response, the expected response body is `{}`.
 
-## Deprovisioning 
+## Deprovisioning
 
-When a broker receives a deprovision request from the marketplace, it should
+When a broker receives a deprovision request from the marketplace, it MUST
 delete any resources it created during the provision.
 Usually this means that all resources are immediately reclaimed for future
 provisions.
@@ -697,9 +706,9 @@ The request provides these query string parameters as useful hints for brokers.
 |---|---|---|
 | service_id* | string | ID of the service from the catalog. |
 | plan_id* | string | ID of the plan from the catalog. |
-| accepts_incomplete  | boolean | A value of true indicates that both the marketplace and the requesting client support asynchronous deprovisioning. If this parameter is not included in the request, and the broker can only deprovision an instance of the requested plan asynchronously, the broker should reject the request with a 422 as described below. |
+| accepts_incomplete  | boolean | A value of true indicates that both the marketplace and the requesting client support asynchronous deprovisioning. If this parameter is not included in the request, and the broker can only deprovision an instance of the requested plan asynchronously, the broker MUST reject the request with a 422 as described below. |
 
-\* Query parameters with an asterisk are required.
+\* Query parameters with an asterisk are REQUIRED.
 
 ##### cURL #####
 <pre class="terminal">
@@ -713,23 +722,23 @@ $ curl 'http://username:password@broker-url/v2/service_instances/:instance_id?ac
 |---|---|
 | 200 OK | Service instance was deleted. The expected response body is <code>{}</code>. |
 | 202 Accepted | Service instance deletion is in progress. This triggers the marketplace to poll the [Service Instance Last Operation Endpoint](#polling) for operation status.  |
-| 410 Gone | Should be returned if the service instance does not exist. The expected response body is <code>{}</code>.  |
-| 422 Unprocessable Entity | Should be returned if the broker only supports asynchronous deprovisioning for the requested plan and the request did not include <code>?accepts_incomplete=true</code>. The expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code>, as described below.  |
+| 410 Gone | MUST be returned if the service instance does not exist. The expected response body is <code>{}</code>.  |
+| 422 Unprocessable Entity | MUST be returned if the broker only supports asynchronous deprovisioning for the requested plan and the request did not include <code>?accepts_incomplete=true</code>. The expected response body is: <code>{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }</code>, as described below.  |
 
 Responses with any other status code will be interpreted as a failure and the service instance will remain in the marketplace database. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
 ##### Body #####
 
-All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
 
 For success responses, the following fields are supported. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
 
 
 |  Response field | Type | Description |
 |---|---|---|
-| operation  | string  | For asynchronous responses, service brokers may return an identifier representing the operation. The value of this field should be provided by the broker client with requests to the [Last Operation](#polling) endpoint in a URL encoded query parameter. |
+| operation  | string  | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field SHOULD be provided by the broker client with requests to the [Last Operation](#polling) endpoint in a URL encoded query parameter. |
 
-\* Fields with an asterisk are required.
+\* Fields with an asterisk are REQUIRED.
 
 <pre class="terminal">
 {
@@ -737,17 +746,17 @@ For success responses, the following fields are supported. Others will be ignore
 }
 </pre>
 
-## Broker Errors 
+## Broker Errors
 
 ### Response ###
 
 Broker failures beyond the scope of the well-defined HTTP response codes listed
-above (like 410 on delete) should return an appropriate HTTP response code
+above (like 410 on delete) MUST return an appropriate HTTP response code
 (chosen to accurately reflect the nature of the failure) and a body containing a valid JSON Object (not an array).
 
 ##### Body #####
 
-All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
+All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
 
 For error responses, the following fields are valid. Others will be ignored. If an empty JSON object is returned in the body `{}`, a generic message containing the HTTP response code returned by the broker will be displayed to the requester.
 
@@ -767,9 +776,9 @@ The platform marketplace is the source of truth for service instances and bindin
 
 Orphans can result if the broker does not return a response before a request from the marketplace times out (typically 60 seconds). For example, if a broker does not return a response to a provision request before the request times out, the broker might eventually succeed in provisioning an instance after the marketplace considers the request a failure. This results in an orphan instance on the broker's side.
 
-To mitigate orphan instances and bindings, the marketplace should attempt to delete resources it cannot be sure were successfully created, and should keep trying to delete them until the broker responds with a success. 
+To mitigate orphan instances and bindings, the marketplace SHOULD attempt to delete resources it cannot be sure were successfully created, and SHOULD keep trying to delete them until the broker responds with a success.
 
-Platforms should initiate orphan mitigation in the following scenarios:
+Platforms SHOULD initiate orphan mitigation in the following scenarios:
 
 | Status code of broker response | Platform interpretation of response | Platform initiates orphan mitigation? |
 |---|---|---|
@@ -783,4 +792,4 @@ Platforms should initiate orphan mitigation in the following scenarios:
 | 5xx | Broker error | Yes |
 | Timeout | Failure | Yes |
 
-If the platform marketplace encounters an internal error provisioning an instance or binding (for example, saving to the database fails), then it should at least send a single delete or unbind request to the service broker to prevent creation of an orphan.
+If the platform marketplace encounters an internal error provisioning an instance or binding (for example, saving to the database fails), then it MUST at least send a single delete or unbind request to the service broker to prevent creation of an orphan.


### PR DESCRIPTION
This is the first of many PRs to migrate the spec to use RFC2119 keywords
to tighten up the language so its clear when things are required vs just
optional/guidance.

In this pass:
- add a title header
- added a "Notational Conventions"  section - to bring in RFC2119
- move "Changes" section down one section since I think "API Overview"
  is more important. We should really add an "Abstract" section at some
  point too.
- for each RFC2119 keyword already in the spec I either made it all CAPS or
  replaced it with a more appropate word. Note that sometimes we were
  using the word w/o meaning for it to be normative, like in examples.
  Sometimes I did swap things like "should" for "MUST" when it seemed
  like that was the real intent. But please do look over each one to make
  sure I didn't go too far.
- Related to the previous one, I tried to avoid tighening the language
  in the spec in most cases because I was hoping to limit this to more of
  a syntax change PR and we can leave PRs that might impact semantics for
  follow-on PRs.

Signed-off-by: Doug Davis <dug@us.ibm.com>