### PR TITLE
Add anchors to fix ToC

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -21,9 +21,9 @@
   - [Broker Errors](#broker-errors)
   - [Orphans](#orphans)
 
-## Changes
+## <a id='changes'></a>Changes
 
-### Change Policy 
+### <a id='change-policy'></a>Change Policy 
 
 * Existing endpoints and fields will not be removed or renamed.
 * New optional endpoints, or new HTTP methods for existing endpoints, may be
@@ -32,11 +32,11 @@ added to enable support for new features.
 These fields must be optional and should be ignored by clients and servers
 that do not understand them.
 
-## Changes Since v2.10
+## <a id='since-v2.10'></a>Changes Since v2.10
 
 * Add <tt>bindable</tt> field to [Plan Object](#PObject) to allow services to have both bindable and non-bindable plans.
 
-## API Overview 
+## <a id='api-overview'></a>API Overview 
 
 The Service Broker API defines an HTTP interface between the services marketplace of a platform and service brokers.
 
@@ -48,7 +48,7 @@ What a binding represents may also vary by service. In general creation of a bin
 
 A platform marketplace may expose services from one or many service brokers, and an individual service broker may support one or many platform marketplaces using different URL prefixes and credentials.
 
-## API Version Header
+## <a id='version-header'></A>API Version Header
 
 Requests from the platform to the service broker must contain a header that declares the version number of the Service Broker API that the marketplace will use:
 
@@ -58,12 +58,12 @@ The version numbers are in the format `MAJOR.MINOR`, using semantic versioning s
 
 This header allows brokers to reject requests from marketplaces for versions they do not support. While minor API revisions will always be additive, it is possible that brokers depend on a feature from a newer version of the API that is supported by the platform. In this scenario the broker may reject the request with `412 Precondition Failed` and provide a message that informs the operator of the required API version.
 
-## Authentication
+## <a id='authentication'></a>Authentication
 
 The marketplace must authenticate with the service broker using HTTP
 basic authentication (the `Authorization:` header) on every request. The broker is responsible for validating the username and password and returning a `401 Unauthorized` message if credentials are invalid. It is recommended that brokers support secure communication from platform marketplaces over TLS.
 
-## Catalog Management 
+## <a id='catalog-mgmt'></a>Catalog Management 
 
 The first endpoint that a broker must implement is the service catalog.
 
@@ -224,11 +224,11 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
 </pre>
 
 
-### Adding a Broker to the Platform 
+### <a id='adding-brokerplatofmr'></a>Adding a Broker to the Platform 
 
 After implementing the first endpoint `GET /v2/catalog` documented [above](#catalog-mgmt), you must register the service broker with your platform to make your services and plans available to end users.
 
-## Synchronous and Asynchronous Operations 
+## <a id='synchronous-asynchronous'></a>Synchronous and Asynchronous Operations 
 
 Broker clients expect prompt responses to all API requests in order to provide users with fast feedback. Service broker authors should implement their brokers to respond promptly to all requests but must decide whether to implement synchronous or asynchronous responses. Brokers that can guarantee completion of the requested operation with the response should return the synchronous response. Brokers that cannot guarantee completion of the operation with the response should implement the asynchronous response.
 
@@ -236,13 +236,13 @@ Providing a synchronous response for a provision, update, or bind operation befo
 
 Support for synchronous or asynchronous responses may vary by service offering, even by service plan.
 
-### Synchronous Operations 
+### <a id='synchronous-operations'></a>Synchronous Operations 
 
 To execute a request synchronously, the broker need only return the usual status codes: `201 CREATED` for provision and bind, and `200 OK` for update, unbind, and deprovision.
 
 Brokers that support sychronous responses for provision, update, and delete can ignore the `accepts_incomplete=true` query parameter if it is provided by the client.
 
-### Asynchronous Operations 
+### <a id='asynchronous-operations'></a>Asynchronous Operations 
 
 <p class='note'><strong>Note:</strong> Asynchronous operations are currently supported only for provision, update, and deprovision.</p>
 
@@ -263,7 +263,7 @@ An asynchronous response triggers the platform marketplace to poll the endpoint 
 
 The marketplace must ensure that service brokers do not receive requests for an instance while an asynchronous operation is in progress. For example, if a broker is in the process of provisioning an instance asynchronously, the marketplace must not allow any update, bind, unbind, or deprovision requests to be made through the platform. A user who attempts to perform one of these actions while an operation is already in progress must receive an HTTP 400 response with the error message: `Another operation for this service instance is in progress`.
 
-## Polling Last Operation 
+## <a id='polling'></a>Polling Last Operation 
 
 When a broker returns status code `202 ACCEPTED` for [provision](#provisioning), [update](#updating_service_instance), or [deprovision](#deprovisioning), the platform will begin polling the `/v2/service_instances/:guid/last_operation` endpoint to obtain the state of the last requested operation. The broker response must contain the field `state` and an optional field `description`.
 
@@ -320,11 +320,11 @@ For success responses, the following fields are valid.
 }
 </pre>
 
-### Polling Interval and Duration    
+### <a id='polling-interval-and-duration'></a>Polling Interval and Duration    
 
 The frequency and maximum duration of polling may vary by platform client. If a platform has a max polling duration and this limit is reached, the platform will cease polling and the operation state will be considered `failed`.
 
-## Provisioning
+## <a id='provisioning'></a>Provisioning
 
 When the broker receives a provision request from the platform, it should take whatever action is necessary to create a new resource. What provisioning represents varies by service and plan, although there are several common use cases. For a MySQL service, provisioning could result in an empty dedicated database server running on its own VM or an empty schema on a shared database server. For non-data services, provisioning could just mean an account on an multi-tenant SaaS application.
 
@@ -407,7 +407,7 @@ For success responses, a broker may return the following fields. For error respo
 }
 </pre>
 
-## Updating a Service Instance 
+## <a id='updating-service-instance'></a>Updating a Service Instance 
 
 By implementing this endpoint, service broker authors can enable users to modify two attributes of an existing service instance: the service plan and parameters. By changing the service plan, users can upgrade or downgrade their service instance to other plans. By modifying properties, users can change configuration options that are specific to a service or plan.
 
@@ -502,13 +502,13 @@ For success responses, a broker may return the following field. Others will be i
 </pre>
 
 
-## Binding 
+## <a id='binding'></a>Binding 
 
 If `bindable:true` is declared for a service or plan in the [Catalog](#catalog-mgmt) endpoint, broker clients may request generation of a service binding. 
 
 <p class="note"><strong>Note</strong>: Not all services must be bindable --- some deliver value just from being provisioned. Brokers that offer services that are bindable should declare them as such using <code>bindable: true</code> in the <a href="#catalog-mgmt">Catalog</a>. Brokers that do not offer any bindable services do not need to implement the endpoint for bind requests.</p>
 
-### Types of Binding 
+### <a id='types-of-binding'></a>Types of Binding 
 
 #### Credentials ####
 
@@ -621,7 +621,7 @@ For success responses, the following fields are supported. Others will be ignore
     }
 </pre>
 
-## Unbinding 
+## <a id='unbinding'></a>Unbinding 
 
 <p class="note"><strong>Note</strong>: Brokers that do not provide any bindable services or plans do not need to implement this endpoint.</p>
 
@@ -666,7 +666,7 @@ All response bodies must be a valid JSON Object (`{}`). This is for future compa
 
 For a success response, the expected response body is `{}`.
 
-## Deprovisioning 
+## <a id='deprovisioning'></a>Deprovisioning 
 
 When a broker receives a deprovision request from the marketplace, it should
 delete any resources it created during the provision.
@@ -728,7 +728,7 @@ For success responses, the following fields are supported. Others will be ignore
 }
 </pre>
 
-## Broker Errors 
+## <a id='broker-errors'></a>Broker Errors 
 
 ### Response ###
 
@@ -752,7 +752,7 @@ For error responses, the following fields are valid. Others will be ignored. If 
 }
 </pre>
 
-## Orphans
+## <a id='orphans'></a>Orphans
 
 The platform marketplace is the source of truth for service instances and bindings. Service brokers are expected to have successfully provisioned all the instances and bindings that the marketplace knows about, and none that it doesn't.
 


### PR DESCRIPTION
This PR should make the linked ToC at the top of http://docs.cloudfoundry.org/services/api.html work. Also, I wasn't sure how deep you wanted the ToC to go, but you can add additional anchor links to any headers that you want reflected in the ToC.