### PR TITLE
Clarify when route_service_url is required

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -239,7 +239,7 @@ After implementing the first endpoint `GET /v2/catalog` documented [above](#cata
 
 ## Synchronous and Asynchronous Operations
 
-Broker clients expect prompt responses to all API requests in order to provide users with fast feedback. Service broker authors SHOULD implement their brokers to respond promptly to all requests but will need to decide whether to implement synchronous or asynchronous responses. Brokers that can guarantee completion of the requested operation with the response SHOULD return the synchronous response. Brokers that cannot guarantee completion of the operation with the response SHOULD implement the asynchronous response.
+Platforms expect prompt responses to all API requests in order to provide users with fast feedback. Service broker authors SHOULD implement their brokers to respond promptly to all requests but will need to decide whether to implement synchronous or asynchronous responses. Brokers that can guarantee completion of the requested operation with the response SHOULD return the synchronous response. Brokers that cannot guarantee completion of the operation with the response SHOULD implement the asynchronous response.
 
 Providing a synchronous response for a provision, update, or bind operation before actual completion causes confusion for users as their service might not be usable and they have no way to find out when it will be. Asynchronous responses set expectations for users that an operation is in progress and can also provide updates on the status of the operation.
 
@@ -291,7 +291,7 @@ The request provides these query string parameters as useful hints for brokers.
 | --- | --- | --- |
 | service_id | string | ID of the service from the catalog. If present, MUST be a non-empty string. |
 | plan_id | string | ID of the plan from the catalog. If present, MUST be a non-empty string. |
-| operation | string | A broker-provided identifier for the operation. When a value for `operation` is included with asynchronous responses for [Provision](#provisioning), [Update](#updating-a-service-instance), and [Deprovision](#deprovisioning) requests, the broker client MUST provide the same value using this query parameter as a URL-encoded string. If present, MUST be a non-empty string. |
+| operation | string | A broker-provided identifier for the operation. When a value for `operation` is included with asynchronous responses for [Provision](#provisioning), [Update](#updating-a-service-instance), and [Deprovision](#deprovisioning) requests, the platform MUST provide the same value using this query parameter as a URL-encoded string. If present, MUST be a non-empty string. |
 
 <p class="note">Note: Although the request query parameters `service_id` and `plan_id` are not mandatory, the platform SHOULD include them on all `last_operation` requests it makes to service brokers.</p>
 
@@ -406,8 +406,8 @@ For success responses, a broker MUST return the following fields. For error resp
 
 | Response field | Type | Description |
 | --- | --- | --- |
-| dashboard_url | string | The URL of a web-based management user interface for the service instance; we refer to this as a service dashboard. The URL MUST contain enough information for the dashboard to identify the resource being accessed (`9189kdfsk0vfnku` in the example below).  Note: a broker that wishes to return `dashboard_url` for a service instance MUST return it with the initial response to the provision request, even if the service is provisioned asynchronously. If present, MUST be a non-empty string. |
-| operation | string | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field SHOULD be provided by the broker client with requests to the [Last Operation](#polling-last-operation) endpoint in a URL encoded query parameter.  If present, MUST be a non-empty string. |
+| dashboard_url | string | The URL of a web-based management user interface for the service instance; we refer to this as a service dashboard. The URL MUST contain enough information for the dashboard to identify the resource being accessed (`9189kdfsk0vfnku` in the example below). Note: a broker that wishes to return `dashboard_url` for a service instance MUST return it with the initial response to the provision request, even if the service is provisioned asynchronously. If present, MUST be a non-empty string. |
+| operation | string | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field MUST be provided by the platform with requests to the [Last Operation](#polling-last-operation) endpoint in a URL encoded query parameter.  If present, MUST be a non-empty string. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -506,7 +506,7 @@ For success responses, a broker MUST return the following field. Others will be 
 
 | Response field | Type | Description |
 | --- | --- | --- |
-| operation | string | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field MUST be provided by the broker client with requests to the [Last Operation](#polling-last-operation) endpoint in a URL encoded query parameter. If present, MUST be a non-empty string. |
+| operation | string | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field MUST be provided by the platform with requests to the [Last Operation](#polling-last-operation) endpoint in a URL encoded query parameter. If present, MUST be a non-empty string. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -519,7 +519,7 @@ For success responses, a broker MUST return the following field. Others will be 
 
 ## Binding
 
-If `bindable:true` is declared for a service or plan in the [Catalog](#catalog-management) endpoint, broker clients MAY request generation of a service binding.
+If `bindable:true` is declared for a service or plan in the [Catalog](#catalog-management) endpoint, the platform MAY request generation of a service binding.
 
 <p class="note">Note: Not all services need to be bindable --- some deliver value just from being provisioned. Brokers that offer services that are bindable MUST declare them as such using `bindable: true` in the [Catalog](#catalog-management). Brokers that do not offer any bindable services do not need to implement the endpoint for bind requests.</p>
 
@@ -531,23 +531,49 @@ Credentials are a set of information used by an application or a user to utilize
 
 #### Log Drain
 
-There are a class of service offerings that provide aggregation, indexing, and analysis of log data. To utilize these services an application that generates logs needs information for the location to which it will stream logs. If a broker represents one of these services, it MAY return a `syslog_drain_url` in the response for a request to create a service binding, to which logs MUST be streamed.
+There are a class of service offerings that provide aggregation, indexing, and
+analysis of log data. To utilize these services an application that generates
+logs needs information for the location to which it will stream logs. A
+create binding response from a service broker that provides one of these
+services MUST include a `syslog_drain_url`. The platform MUST use the
+`syslog_drain_url` value when sending logs to the service.
 
-The `requires` field in the [Catalog](#catalog-management) endpoint enables a platform marketplace to validate a response for create binding that includes a `syslog_drain_url`. Platform marketplaces can consider a broker's response invalid if it includes a `syslog_drain_url` and `"requires":["syslog_drain"]` is not present in the [Catalog](#catalog-management) endpoint.
+Brokers MUST NOT include a `syslog_drain_url` in a create binding response
+if the associated [Catalog](#catalog-management) entry for the service
+did not include a `"requires":["syslog_drain"]` property.
 
 #### Route Services
 
-There are a class of service offerings that intermediate requests to applications, performing functions such as rate limiting or authorization. To configure a service instance with behavior specific to an application's routable address, a broker client MAY send the address along with the request to create a binding using `"bind_resource":{"route":"some-address.com"}`.
+There are a class of service offerings that intermediate requests to
+applications, performing functions such as rate limiting or authorization.
 
-Some platforms MAY support proxying of application requests to service instances. In this case the platform needs to know where to send application requests; to facilitate this, the broker MUST return a `route_service_url` in the response for a request to create a binding. Not all services of this type expect to receive requests proxied by the platform; some services will have been configured out-of-band to intermediate requests to applications. In this case, the broker will not return `route_service_url` in response to the create binding request. By sending `bind_resource` as described above, the platform enables dynamic configuration of a service instance already in the application request path for the route, requiring no change in the platform routing tier.
+If a platform supports route services, it MUST send a routable address,
+or endpoint, for the application along with the request to create a service
+binding using `"bind_resource":{"route":"some-address.com"}`. A broker MAY
+support configuration specific to an address using parameters; exposing this
+feature to users would require a platform to support binding multiple
+routable addresses to the same service instance.
 
-The `requires` field in the [Catalog](#catalog-management) endpoint enables a platform marketplace to validate requests to create bindings. A platform MAY reject requests to create bindings when a broker has declared `"requires":["route_forwarding"]` for a service in the catalog endpoint.
+If a service is deployed in a configuration to support this behavior, the
+broker MUST return a `route_service_url` in the response for a request to
+create a binding, so that the platform knows where to proxy the application
+request.  If the service is deployed such that the network configuration to
+proxy application requests through instances of the service is managed
+out-of-band, the broker MUST NOT return `route_service_url` in the response.
+
+Brokers MUST NOT include a `route_service_url` in a create binding response
+if the associated [Catalog](#catalog-management) entry for the service
+did not include a `"requires":["route_forwarding"]` property.
 
 #### Volume Services
 
-There are a class of services that provide network storage to applications via volume mounts in the application container. A service broker MUST return data needed for this configuration with `volume_mount` in response to the request to create a binding.
+There are a class of services that provide network storage to applications
+via volume mounts in the application container. A create binding response
+from one of these services MUST include a `volume_mount`.
 
-The `requires` field in the [Catalog](#catalog-management) endpoint enables a platform marketplace to validate a response for create binding that includes a `volume_mounts`. Platform marketplaces can consider a broker's response invalid if it includes a `volume_mounts` and `"requires":["volume_mount"]` is not present in the [Catalog](#catalog-management) endpoint.
+Brokers MUST NOT include a `volume_mounts` in a create binding response
+if the associated [Catalog](#catalog-management) entry for the service
+did not include a `"requires":["volume_mount"]` property.
 
 ### Request
 
@@ -748,7 +774,7 @@ For success responses, the following fields are supported. Others will be ignore
 
 | Response field | Type | Description |
 | --- | --- | --- |
-| operation | string | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field MUST be provided by the broker client with requests to the [Last Operation](#polling-last-operation) endpoint in a URL encoded query parameter. If present, MUST be a non-empty string. |
+| operation | string | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field MUST be provided by the platform with requests to the [Last Operation](#polling-last-operation) endpoint in a URL encoded query parameter. If present, MUST be a non-empty string. |
 
 \* Fields with an asterisk are REQUIRED.
 


### PR DESCRIPTION
Clarify when route_service_url is required
    
See: https://github.com/openservicebrokerapi/servicebroker/pull/166/files#r113097378
    
Closes: #169
    
Add some clarity around when a broker can return extra data in the bindings
    
I decided to reword this to be a requirement on the broker. Talking about
the platform didn't make any sense to me since we can't really say anything
normative about it from the POV.
    
While in there I also `s/broker client/platform/g` for consistency.

Signed-off-by: Doug Davis <dug@us.ibm.com>