### PR TITLE
Latest release should link to spec (not git branch)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![Open Service Broker API](https://www.openservicebrokerapi.org/wp-content/uploads/2016/12/osbapi_logo_concept3_wtm.png)
 
 ## Latest Release: v2.11
-[Read the specification](https://github.com/openservicebrokerapi/servicebroker/tree/v2.11)
+[Read the specification](https://github.com/openservicebrokerapi/servicebroker/tree/v2.11/spec.md)
 
 [Release Notes for past versions](release-notes.md)
 


### PR DESCRIPTION
Hopefully a simple one. It's a little annoying having to click twice to see the spec.