### PR TITLE
Add master to title

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,4 +1,4 @@
-# Open Service Broker API
+# Open Service Broker API (v2.11)
 
 ## Table of Contents
   - [API Overview](#api-overview)


### PR DESCRIPTION
I think we should make it obvious which version people are looking at, especially since Cloud Foundry and other platforms may pull this spec in to form part of their own documentation.

The version 2.11 is already present in the docs, but this change just adds it to the title to make it clearer.