### PR TITLE
moving content for volume mounts from cf docs into 2.11

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -621,7 +621,7 @@ For success responses, the following fields are supported. Others will be ignore
 | driver* | string | Name of the volume driver plugin which manages the device. |
 | container_dir* | string | The path in the application container onto which the volume will be mounted. This specification does not mandate what action the platform is to take if the path specified already exists in the container. |
 | mode* | string | "r" to mount the volume read-only or "rw" to mount it read-write. |
-| device_type* | string | A string specifying the type of device to mount. Currently the only supported value is "shared".  |
+| device_type* | string | A string specifying the type of device to mount. Currently the only supported value is "shared". |
 | device* | device-object | Device object containing device_type specific details. Currently only shared devices are supported. |
 
 ##### Device Object

--- a/spec.md
+++ b/spec.md
@@ -22,11 +22,11 @@
   - [Broker Errors](#broker-errors)
   - [Orphans](#orphans)
 
-<div id="changes"/> 
+<div id="changes"/>
 ## Changes ##
 
 <div id="change-policy"/>
-###Change Policy 
+###Change Policy
 
 * Existing endpoints and fields will not be removed or renamed.
 * New optional endpoints, or new HTTP methods for existing endpoints, may be
@@ -40,8 +40,8 @@ that do not understand them.
 
 * Add <tt>bindable</tt> field to [Plan Object](#PObject) to allow services to have both bindable and non-bindable plans.
 
-<div id="api-overview"/> 
-##API Overview 
+<div id="api-overview"/>
+##API Overview
 
 The Service Broker API defines an HTTP interface between the services marketplace of a platform and service brokers.
 
@@ -64,14 +64,14 @@ The version numbers are in the format `MAJOR.MINOR`, using semantic versioning s
 
 This header allows brokers to reject requests from marketplaces for versions they do not support. While minor API revisions will always be additive, it is possible that brokers depend on a feature from a newer version of the API that is supported by the platform. In this scenario the broker may reject the request with `412 Precondition Failed` and provide a message that informs the operator of the required API version.
 
-<div id="authentication"/> 
+<div id="authentication"/>
 ## Authentication
 
 The marketplace must authenticate with the service broker using HTTP
 basic authentication (the `Authorization:` header) on every request. The broker is responsible for validating the username and password and returning a `401 Unauthorized` message if credentials are invalid. It is recommended that brokers support secure communication from platform marketplaces over TLS.
 
 <div id="catalog-mgmt"/>
-## Catalog Management 
+## Catalog Management
 
 The first endpoint that a broker must implement is the service catalog.
 
@@ -233,12 +233,12 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
 
 
 <div id="adding-broker-platform"/>
-### Adding a Broker to the Platform 
+### Adding a Broker to the Platform
 
 After implementing the first endpoint `GET /v2/catalog` documented [above](#catalog-mgmt), you must register the service broker with your platform to make your services and plans available to end users.
 
 <div id="synchronous-asynchronous"</a>
-## Synchronous and Asynchronous Operations 
+## Synchronous and Asynchronous Operations
 
 Broker clients expect prompt responses to all API requests in order to provide users with fast feedback. Service broker authors should implement their brokers to respond promptly to all requests but must decide whether to implement synchronous or asynchronous responses. Brokers that can guarantee completion of the requested operation with the response should return the synchronous response. Brokers that cannot guarantee completion of the operation with the response should implement the asynchronous response.
 
@@ -247,14 +247,14 @@ Providing a synchronous response for a provision, update, or bind operation befo
 Support for synchronous or asynchronous responses may vary by service offering, even by service plan.
 
 <div id="synchronous-operations"/>
-### Synchronous Operations 
+### Synchronous Operations
 
 To execute a request synchronously, the broker need only return the usual status codes: `201 CREATED` for provision and bind, and `200 OK` for update, unbind, and deprovision.
 
 Brokers that support sychronous responses for provision, update, and delete can ignore the `accepts_incomplete=true` query parameter if it is provided by the client.
 
 <div id="asynchronous-operations"/>
-### Asynchronous Operations 
+### Asynchronous Operations
 
 <p class='note'><strong>Note:</strong> Asynchronous operations are currently supported only for provision, update, and deprovision.</p>
 
@@ -276,7 +276,7 @@ An asynchronous response triggers the platform marketplace to poll the endpoint 
 The marketplace must ensure that service brokers do not receive requests for an instance while an asynchronous operation is in progress. For example, if a broker is in the process of provisioning an instance asynchronously, the marketplace must not allow any update, bind, unbind, or deprovision requests to be made through the platform. A user who attempts to perform one of these actions while an operation is already in progress must receive an HTTP 400 response with the error message: `Another operation for this service instance is in progress`.
 
 <div id="polling"/>
-## Polling Last Operation 
+## Polling Last Operation
 
 When a broker returns status code `202 ACCEPTED` for [provision](#provisioning), [update](#updating_service_instance), or [deprovision](#deprovisioning), the platform will begin polling the `/v2/service_instances/:guid/last_operation` endpoint to obtain the state of the last requested operation. The broker response must contain the field `state` and an optional field `description`.
 
@@ -338,7 +338,7 @@ For success responses, the following fields are valid.
 
 The frequency and maximum duration of polling may vary by platform client. If a platform has a max polling duration and this limit is reached, the platform will cease polling and the operation state will be considered `failed`.
 
-<div id="provisioning"/> 
+<div id="provisioning"/>
 ## Provisioning
 
 When the broker receives a provision request from the platform, it should take whatever action is necessary to create a new resource. What provisioning represents varies by service and plan, although there are several common use cases. For a MySQL service, provisioning could result in an empty dedicated database server running on its own VM or an empty schema on a shared database server. For non-data services, provisioning could just mean an account on an multi-tenant SaaS application.
@@ -423,7 +423,7 @@ For success responses, a broker may return the following fields. For error respo
 </pre>
 
 <div id="updating_service_instance"/>
-## Updating a Service Instance 
+## Updating a Service Instance
 
 By implementing this endpoint, service broker authors can enable users to modify two attributes of an existing service instance: the service plan and parameters. By changing the service plan, users can upgrade or downgrade their service instance to other plans. By modifying properties, users can change configuration options that are specific to a service or plan.
 
@@ -519,18 +519,18 @@ For success responses, a broker may return the following field. Others will be i
 
 
 <div id="binding"/>
-## Binding 
+## Binding
 
-If `bindable:true` is declared for a service or plan in the [Catalog](#catalog-mgmt) endpoint, broker clients may request generation of a service binding. 
+If `bindable:true` is declared for a service or plan in the [Catalog](#catalog-mgmt) endpoint, broker clients may request generation of a service binding.
 
 <p class="note"><strong>Note</strong>: Not all services must be bindable --- some deliver value just from being provisioned. Brokers that offer services that are bindable should declare them as such using <code>bindable: true</code> in the <a href="#catalog-mgmt">Catalog</a>. Brokers that do not offer any bindable services do not need to implement the endpoint for bind requests.</p>
 
 <div id="types-of-binding"/>
-### Types of Binding 
+### Types of Binding
 
 #### Credentials ####
 
-Credentials are a set of information used by an application or a user to utilize the service instance. If the broker supports generation of credentials it should return `credentials` in the response for a request to create a service binding. Credentials should be unique whenever possible, so access can be revoked for each binding without affecting consumers of other bindings for the service instance. 
+Credentials are a set of information used by an application or a user to utilize the service instance. If the broker supports generation of credentials it should return `credentials` in the response for a request to create a service binding. Credentials should be unique whenever possible, so access can be revoked for each binding without affecting consumers of other bindings for the service instance.
 
 #### Log Drain ####
 
@@ -539,19 +539,23 @@ There are a class of service offerings that provide aggregation, indexing, and a
 The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate a response for create binding that includes a `syslog_drain_url`. Platform marketplaces should consider a broker's response invalid if it includes a `syslog_drain_url` and `"requires":["syslog_drain"]` is not present in the [Catalog](#catalog-mgmt) endpoint.
 
 <div id= "route_services"/>
-#### Route Services 
+#### Route Services
 
 There are a class of service offerings that intermediate requests to applications, performing functions such as rate limiting or authorization. To configure a service instance with behavior specific to an application's routable address, a broker client may send the address along with the request to create a binding using `"bind_resource":{"route":"some-address.com"}`.
 
-Some platforms may support proxying of application requests to service instances. In this case the platform needs to know where to send application requests; to facilitate this, the broker may return a `route_service_url` in the response for a request to create a binding. Not all services of this type expect to receive requests proxied by the platform; some services will have been configured out-of-band to intermediate requests to applications. In this case, the broker will not return `route_service_url` in response to the create binding request. By sending `bind-resource` as described above, the platform enables dynamic configuration of a service instance already in the application request path for the route, requiring no change in the platform routing tier. 
+Some platforms may support proxying of application requests to service instances. In this case the platform needs to know where to send application requests; to facilitate this, the broker may return a `route_service_url` in the response for a request to create a binding. Not all services of this type expect to receive requests proxied by the platform; some services will have been configured out-of-band to intermediate requests to applications. In this case, the broker will not return `route_service_url` in response to the create binding request. By sending `bind-resource` as described above, the platform enables dynamic configuration of a service instance already in the application request path for the route, requiring no change in the platform routing tier.
 
 The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate requests to create bindings. A platform may opt to reject requests to create bindings when a broker has declared `"requires":["route_forwarding"]` for a service in the catalog endpoint.
 
 #### Volume Services ####
 
-There are a class of services that provide network storage to applications via volume mounts in the application container. A service broker may return data required for this configuration with `volume_mount` in response to the request to create a binding. 
+There are a class of services that provide network storage to applications
+via volume mounts in the application container. A create binding response
+from one of these services MUST include `volume_mounts`.
 
-The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate a response for create binding that includes a `volume_mounts`. Platform marketplaces should consider a broker's response invalid if it includes a `volume_mounts` and `"requires":["volume_mount"]` is not present in the [Catalog](#catalog-mgmt) endpoint.
+Brokers MUST NOT include `volume_mounts` in a create binding response
+if the associated [Catalog](#catalog-management) entry for the service
+did not include a `"requires":["volume_mount"]` property.
 
 ### Request ###
 
@@ -620,6 +624,7 @@ All response bodies must be a valid JSON Object (`{}`). This is for future compa
 
 For success responses, the following fields are supported. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
 
+<<<<<<< HEAD
 |  Response Field | Type  | Description  |
 |---|---|---|
 | credentials  | object  |  A free-form hash of credentials that may be used by applications or users to access the service. |
@@ -641,7 +646,65 @@ For success responses, the following fields are supported. Others will be ignore
 </pre>
 
 <div id="unbinding"/>
-## Unbinding 
+## Unbinding
+=======
+| Response Field | Type | Description |
+| --- | --- | --- |
+| credentials | object | A free-form hash of credentials that can be used by applications or users to access the service. |
+| syslog_drain_url | string | A URL to which logs MUST be streamed. `"requires":["syslog_drain"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the platform MUST consider the response invalid. |
+| route_service_url | string | A URL to which the platform MUST proxy requests for the address sent with `bind_resource.route` in the request body. `"requires":["route_forwarding"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the platform can consider the response invalid. |
+| volume_mounts | array-of-objects | An array of configuration for remote storage devices to be mounted into an application container filesystem. `"requires":["volume_mount"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the platform can consider the response invalid. |
+
+##### Volume Mounts Object
+
+| Response Field | Type | Description |
+| --- | --- | --- |
+| driver | string | Name of the volume driver plugin which manages the device |
+| container_dir | string | The directory to mount inside the application container |
+| mode | string | "r" to mount the volume read-only, or "rw" to mount it read-write |
+| device_type | string | A string specifying the type of device to mount. Currently the only supported value is "shared"  |
+| device | device-object | Device object containing device_type specific details. Currently the only supported value is "shared_device" |
+
+##### Shared Device Object
+
+| Field | Type | Description |
+| --- | --- | --- |
+| volume_id | string | ID of the shared volume to mount on every app instance |
+| mount_config | object | Configuration object to be passed to the driver when the volume is mounted (optional) |
+
+
+```
+{
+  "credentials": {
+    "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
+    "username": "mysqluser",
+    "password": "pass",
+    "host": "mysqlhost",
+    "port": 3306,
+    "database": "dbname"
+  }
+}
+```
+
+```
+{
+  "volume_mounts": [{
+    "driver": "cephdriver",
+    "container_dir": "/data/images",
+    "mode": "r",
+    "device_type": "shared",
+    "device": {
+      "volume_id": "bc2c1eab-05b9-482d-b0cf-750ee07de311",
+      "mount_config": {
+        "key": "value"
+      }
+    }
+  }]
+}
+```
+
+## Unbinding
+>>>>>>> 743bf5e... moving content for volume mounts from cf docs into spec
 
 <p class="note"><strong>Note</strong>: Brokers that do not provide any bindable services or plans do not need to implement this endpoint.</p>
 
@@ -687,7 +750,7 @@ All response bodies must be a valid JSON Object (`{}`). This is for future compa
 For a success response, the expected response body is `{}`.
 
 <div id="deprovisioning"/>
-## Deprovisioning 
+## Deprovisioning
 
 When a broker receives a deprovision request from the marketplace, it should
 delete any resources it created during the provision.
@@ -750,7 +813,7 @@ For success responses, the following fields are supported. Others will be ignore
 </pre>
 
 <div id="broker-errors"/>
-## Broker Errors 
+## Broker Errors
 
 ### Response ###
 
@@ -774,14 +837,14 @@ For error responses, the following fields are valid. Others will be ignored. If 
 }
 </pre>
 
-<div id="orphans"/> 
+<div id="orphans"/>
 ## Orphans
 
 The platform marketplace is the source of truth for service instances and bindings. Service brokers are expected to have successfully provisioned all the instances and bindings that the marketplace knows about, and none that it doesn't.
 
 Orphans can result if the broker does not return a response before a request from the marketplace times out (typically 60 seconds). For example, if a broker does not return a response to a provision request before the request times out, the broker might eventually succeed in provisioning an instance after the marketplace considers the request a failure. This results in an orphan instance on the broker's side.
 
-To mitigate orphan instances and bindings, the marketplace should attempt to delete resources it cannot be sure were successfully created, and should keep trying to delete them until the broker responds with a success. 
+To mitigate orphan instances and bindings, the marketplace should attempt to delete resources it cannot be sure were successfully created, and should keep trying to delete them until the broker responds with a success.
 
 Platforms should initiate orphan mitigation in the following scenarios:
 

--- a/spec.md
+++ b/spec.md
@@ -22,11 +22,11 @@
   - [Broker Errors](#broker-errors)
   - [Orphans](#orphans)
 
-<div id="changes"/>
+<div id="changes"/> 
 ## Changes ##
 
 <div id="change-policy"/>
-###Change Policy
+###Change Policy 
 
 * Existing endpoints and fields will not be removed or renamed.
 * New optional endpoints, or new HTTP methods for existing endpoints, may be
@@ -40,8 +40,8 @@ that do not understand them.
 
 * Add <tt>bindable</tt> field to [Plan Object](#PObject) to allow services to have both bindable and non-bindable plans.
 
-<div id="api-overview"/>
-##API Overview
+<div id="api-overview"/> 
+##API Overview 
 
 The Service Broker API defines an HTTP interface between the services marketplace of a platform and service brokers.
 
@@ -64,14 +64,14 @@ The version numbers are in the format `MAJOR.MINOR`, using semantic versioning s
 
 This header allows brokers to reject requests from marketplaces for versions they do not support. While minor API revisions will always be additive, it is possible that brokers depend on a feature from a newer version of the API that is supported by the platform. In this scenario the broker may reject the request with `412 Precondition Failed` and provide a message that informs the operator of the required API version.
 
-<div id="authentication"/>
+<div id="authentication"/> 
 ## Authentication
 
 The marketplace must authenticate with the service broker using HTTP
 basic authentication (the `Authorization:` header) on every request. The broker is responsible for validating the username and password and returning a `401 Unauthorized` message if credentials are invalid. It is recommended that brokers support secure communication from platform marketplaces over TLS.
 
 <div id="catalog-mgmt"/>
-## Catalog Management
+## Catalog Management 
 
 The first endpoint that a broker must implement is the service catalog.
 
@@ -233,12 +233,12 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
 
 
 <div id="adding-broker-platform"/>
-### Adding a Broker to the Platform
+### Adding a Broker to the Platform 
 
 After implementing the first endpoint `GET /v2/catalog` documented [above](#catalog-mgmt), you must register the service broker with your platform to make your services and plans available to end users.
 
 <div id="synchronous-asynchronous"</a>
-## Synchronous and Asynchronous Operations
+## Synchronous and Asynchronous Operations 
 
 Broker clients expect prompt responses to all API requests in order to provide users with fast feedback. Service broker authors should implement their brokers to respond promptly to all requests but must decide whether to implement synchronous or asynchronous responses. Brokers that can guarantee completion of the requested operation with the response should return the synchronous response. Brokers that cannot guarantee completion of the operation with the response should implement the asynchronous response.
 
@@ -247,14 +247,14 @@ Providing a synchronous response for a provision, update, or bind operation befo
 Support for synchronous or asynchronous responses may vary by service offering, even by service plan.
 
 <div id="synchronous-operations"/>
-### Synchronous Operations
+### Synchronous Operations 
 
 To execute a request synchronously, the broker need only return the usual status codes: `201 CREATED` for provision and bind, and `200 OK` for update, unbind, and deprovision.
 
 Brokers that support sychronous responses for provision, update, and delete can ignore the `accepts_incomplete=true` query parameter if it is provided by the client.
 
 <div id="asynchronous-operations"/>
-### Asynchronous Operations
+### Asynchronous Operations 
 
 <p class='note'><strong>Note:</strong> Asynchronous operations are currently supported only for provision, update, and deprovision.</p>
 
@@ -276,7 +276,7 @@ An asynchronous response triggers the platform marketplace to poll the endpoint 
 The marketplace must ensure that service brokers do not receive requests for an instance while an asynchronous operation is in progress. For example, if a broker is in the process of provisioning an instance asynchronously, the marketplace must not allow any update, bind, unbind, or deprovision requests to be made through the platform. A user who attempts to perform one of these actions while an operation is already in progress must receive an HTTP 400 response with the error message: `Another operation for this service instance is in progress`.
 
 <div id="polling"/>
-## Polling Last Operation
+## Polling Last Operation 
 
 When a broker returns status code `202 ACCEPTED` for [provision](#provisioning), [update](#updating_service_instance), or [deprovision](#deprovisioning), the platform will begin polling the `/v2/service_instances/:guid/last_operation` endpoint to obtain the state of the last requested operation. The broker response must contain the field `state` and an optional field `description`.
 
@@ -338,7 +338,7 @@ For success responses, the following fields are valid.
 
 The frequency and maximum duration of polling may vary by platform client. If a platform has a max polling duration and this limit is reached, the platform will cease polling and the operation state will be considered `failed`.
 
-<div id="provisioning"/>
+<div id="provisioning"/> 
 ## Provisioning
 
 When the broker receives a provision request from the platform, it should take whatever action is necessary to create a new resource. What provisioning represents varies by service and plan, although there are several common use cases. For a MySQL service, provisioning could result in an empty dedicated database server running on its own VM or an empty schema on a shared database server. For non-data services, provisioning could just mean an account on an multi-tenant SaaS application.
@@ -423,7 +423,7 @@ For success responses, a broker may return the following fields. For error respo
 </pre>
 
 <div id="updating_service_instance"/>
-## Updating a Service Instance
+## Updating a Service Instance 
 
 By implementing this endpoint, service broker authors can enable users to modify two attributes of an existing service instance: the service plan and parameters. By changing the service plan, users can upgrade or downgrade their service instance to other plans. By modifying properties, users can change configuration options that are specific to a service or plan.
 
@@ -519,18 +519,18 @@ For success responses, a broker may return the following field. Others will be i
 
 
 <div id="binding"/>
-## Binding
+## Binding 
 
-If `bindable:true` is declared for a service or plan in the [Catalog](#catalog-mgmt) endpoint, broker clients may request generation of a service binding.
+If `bindable:true` is declared for a service or plan in the [Catalog](#catalog-mgmt) endpoint, broker clients may request generation of a service binding. 
 
 <p class="note"><strong>Note</strong>: Not all services must be bindable --- some deliver value just from being provisioned. Brokers that offer services that are bindable should declare them as such using <code>bindable: true</code> in the <a href="#catalog-mgmt">Catalog</a>. Brokers that do not offer any bindable services do not need to implement the endpoint for bind requests.</p>
 
 <div id="types-of-binding"/>
-### Types of Binding
+### Types of Binding 
 
 #### Credentials ####
 
-Credentials are a set of information used by an application or a user to utilize the service instance. If the broker supports generation of credentials it should return `credentials` in the response for a request to create a service binding. Credentials should be unique whenever possible, so access can be revoked for each binding without affecting consumers of other bindings for the service instance.
+Credentials are a set of information used by an application or a user to utilize the service instance. If the broker supports generation of credentials it should return `credentials` in the response for a request to create a service binding. Credentials should be unique whenever possible, so access can be revoked for each binding without affecting consumers of other bindings for the service instance. 
 
 #### Log Drain ####
 
@@ -539,23 +539,19 @@ There are a class of service offerings that provide aggregation, indexing, and a
 The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate a response for create binding that includes a `syslog_drain_url`. Platform marketplaces should consider a broker's response invalid if it includes a `syslog_drain_url` and `"requires":["syslog_drain"]` is not present in the [Catalog](#catalog-mgmt) endpoint.
 
 <div id= "route_services"/>
-#### Route Services
+#### Route Services 
 
 There are a class of service offerings that intermediate requests to applications, performing functions such as rate limiting or authorization. To configure a service instance with behavior specific to an application's routable address, a broker client may send the address along with the request to create a binding using `"bind_resource":{"route":"some-address.com"}`.
 
-Some platforms may support proxying of application requests to service instances. In this case the platform needs to know where to send application requests; to facilitate this, the broker may return a `route_service_url` in the response for a request to create a binding. Not all services of this type expect to receive requests proxied by the platform; some services will have been configured out-of-band to intermediate requests to applications. In this case, the broker will not return `route_service_url` in response to the create binding request. By sending `bind-resource` as described above, the platform enables dynamic configuration of a service instance already in the application request path for the route, requiring no change in the platform routing tier.
+Some platforms may support proxying of application requests to service instances. In this case the platform needs to know where to send application requests; to facilitate this, the broker may return a `route_service_url` in the response for a request to create a binding. Not all services of this type expect to receive requests proxied by the platform; some services will have been configured out-of-band to intermediate requests to applications. In this case, the broker will not return `route_service_url` in response to the create binding request. By sending `bind-resource` as described above, the platform enables dynamic configuration of a service instance already in the application request path for the route, requiring no change in the platform routing tier. 
 
 The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate requests to create bindings. A platform may opt to reject requests to create bindings when a broker has declared `"requires":["route_forwarding"]` for a service in the catalog endpoint.
 
 #### Volume Services ####
 
-There are a class of services that provide network storage to applications
-via volume mounts in the application container. A create binding response
-from one of these services MUST include `volume_mounts`.
+There are a class of services that provide network storage to applications via volume mounts in the application container. A service broker may return data required for this configuration with `volume_mount` in response to the request to create a binding. 
 
-Brokers MUST NOT include `volume_mounts` in a create binding response
-if the associated [Catalog](#catalog-management) entry for the service
-did not include a `"requires":["volume_mount"]` property.
+The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate a response for create binding that includes a `volume_mounts`. Platform marketplaces should consider a broker's response invalid if it includes a `volume_mounts` and `"requires":["volume_mount"]` is not present in the [Catalog](#catalog-mgmt) endpoint.
 
 ### Request ###
 
@@ -624,7 +620,6 @@ All response bodies must be a valid JSON Object (`{}`). This is for future compa
 
 For success responses, the following fields are supported. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
 
-<<<<<<< HEAD
 |  Response Field | Type  | Description  |
 |---|---|---|
 | credentials  | object  |  A free-form hash of credentials that may be used by applications or users to access the service. |
@@ -646,65 +641,7 @@ For success responses, the following fields are supported. Others will be ignore
 </pre>
 
 <div id="unbinding"/>
-## Unbinding
-=======
-| Response Field | Type | Description |
-| --- | --- | --- |
-| credentials | object | A free-form hash of credentials that can be used by applications or users to access the service. |
-| syslog_drain_url | string | A URL to which logs MUST be streamed. `"requires":["syslog_drain"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the platform MUST consider the response invalid. |
-| route_service_url | string | A URL to which the platform MUST proxy requests for the address sent with `bind_resource.route` in the request body. `"requires":["route_forwarding"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the platform can consider the response invalid. |
-| volume_mounts | array-of-objects | An array of configuration for remote storage devices to be mounted into an application container filesystem. `"requires":["volume_mount"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the platform can consider the response invalid. |
-
-##### Volume Mounts Object
-
-| Response Field | Type | Description |
-| --- | --- | --- |
-| driver | string | Name of the volume driver plugin which manages the device |
-| container_dir | string | The directory to mount inside the application container |
-| mode | string | "r" to mount the volume read-only, or "rw" to mount it read-write |
-| device_type | string | A string specifying the type of device to mount. Currently the only supported value is "shared"  |
-| device | device-object | Device object containing device_type specific details. Currently the only supported value is "shared_device" |
-
-##### Shared Device Object
-
-| Field | Type | Description |
-| --- | --- | --- |
-| volume_id | string | ID of the shared volume to mount on every app instance |
-| mount_config | object | Configuration object to be passed to the driver when the volume is mounted (optional) |
-
-
-```
-{
-  "credentials": {
-    "uri": "mysql://mysqluser:pass@mysqlhost:3306/dbname",
-    "username": "mysqluser",
-    "password": "pass",
-    "host": "mysqlhost",
-    "port": 3306,
-    "database": "dbname"
-  }
-}
-```
-
-```
-{
-  "volume_mounts": [{
-    "driver": "cephdriver",
-    "container_dir": "/data/images",
-    "mode": "r",
-    "device_type": "shared",
-    "device": {
-      "volume_id": "bc2c1eab-05b9-482d-b0cf-750ee07de311",
-      "mount_config": {
-        "key": "value"
-      }
-    }
-  }]
-}
-```
-
-## Unbinding
->>>>>>> 743bf5e... moving content for volume mounts from cf docs into spec
+## Unbinding 
 
 <p class="note"><strong>Note</strong>: Brokers that do not provide any bindable services or plans do not need to implement this endpoint.</p>
 
@@ -750,7 +687,7 @@ All response bodies must be a valid JSON Object (`{}`). This is for future compa
 For a success response, the expected response body is `{}`.
 
 <div id="deprovisioning"/>
-## Deprovisioning
+## Deprovisioning 
 
 When a broker receives a deprovision request from the marketplace, it should
 delete any resources it created during the provision.
@@ -813,7 +750,7 @@ For success responses, the following fields are supported. Others will be ignore
 </pre>
 
 <div id="broker-errors"/>
-## Broker Errors
+## Broker Errors 
 
 ### Response ###
 
@@ -837,14 +774,14 @@ For error responses, the following fields are valid. Others will be ignored. If 
 }
 </pre>
 
-<div id="orphans"/>
+<div id="orphans"/> 
 ## Orphans
 
 The platform marketplace is the source of truth for service instances and bindings. Service brokers are expected to have successfully provisioned all the instances and bindings that the marketplace knows about, and none that it doesn't.
 
 Orphans can result if the broker does not return a response before a request from the marketplace times out (typically 60 seconds). For example, if a broker does not return a response to a provision request before the request times out, the broker might eventually succeed in provisioning an instance after the marketplace considers the request a failure. This results in an orphan instance on the broker's side.
 
-To mitigate orphan instances and bindings, the marketplace should attempt to delete resources it cannot be sure were successfully created, and should keep trying to delete them until the broker responds with a success.
+To mitigate orphan instances and bindings, the marketplace should attempt to delete resources it cannot be sure were successfully created, and should keep trying to delete them until the broker responds with a success. 
 
 Platforms should initiate orphan mitigation in the following scenarios:
 

--- a/spec.md
+++ b/spec.md
@@ -619,7 +619,7 @@ For success responses, the following fields are supported. Others will be ignore
 | Response Field | Type | Description |
 | --- | --- | --- |
 | driver* | string | Name of the volume driver plugin which manages the device. |
-| container_dir* | string | The path in the application container onto which the volume will be mounted. |
+| container_dir* | string | The path in the application container onto which the volume will be mounted. This specification does not mandate what action the platform is to take if the path specified already exists in the container. |
 | mode* | string | "r" to mount the volume read-only or "rw" to mount it read-write. |
 | device_type* | string | A string specifying the type of device to mount. Currently the only supported value is "shared".  |
 | device* | device-object | Device object containing device_type specific details. Currently only shared devices are supported. |

--- a/spec.md
+++ b/spec.md
@@ -618,19 +618,22 @@ For success responses, the following fields are supported. Others will be ignore
 
 | Response Field | Type | Description |
 | --- | --- | --- |
-| driver | string | Name of the volume driver plugin which manages the device |
-| container_dir | string | The directory to mount inside the application container |
-| mode | string | "r" to mount the volume read-only, or "rw" to mount it read-write |
-| device_type | string | A string specifying the type of device to mount. Currently the only supported value is "shared"  |
-| device | device-object | Device object containing device_type specific details. Currently the only supported value is "shared_device" |
+| driver* | string | Name of the volume driver plugin which manages the device. |
+| container_dir* | string | The path in the application container onto which the volume will be mounted. |
+| mode* | string | "r" to mount the volume read-only or "rw" to mount it read-write. |
+| device_type* | string | A string specifying the type of device to mount. Currently the only supported value is "shared".  |
+| device* | device-object | Device object containing device_type specific details. Currently only shared devices are supported. |
 
-##### Shared Device Object
+##### Device Object
+
+Currently only shared devices are supported; a distributed file system which can be mounted on all app instances simultaneously.
 
 | Field | Type | Description |
 | --- | --- | --- |
-| volume_id | string | ID of the shared volume to mount on every app instance |
-| mount_config | object | Configuration object to be passed to the driver when the volume is mounted (optional) |
+| volume_id* | string | ID of the shared volume to mount on every app instance. |
+| mount_config | object | Configuration object to be passed to the driver when the volume is mounted. |
 
+\* Fields with an asterisk are REQUIRED.
 
 ```
 {

--- a/spec.md
+++ b/spec.md
@@ -1,4 +1,6 @@
-#Table of Contents#
+# Open Service Broker API v2.11
+
+## Table of Contents
   - [API Release Notes](#release-notes)
   - [Changes](#changes)
     - [Change Policy](#change-policy)
@@ -22,26 +24,7 @@
   - [Broker Errors](#broker-errors)
   - [Orphans](#orphans)
 
-<div id="changes"/> 
-## Changes ##
-
-<div id="change-policy"/>
-###Change Policy 
-
-* Existing endpoints and fields will not be removed or renamed.
-* New optional endpoints, or new HTTP methods for existing endpoints, may be
-added to enable support for new features.
-* New fields may be added to existing request/response messages.
-These fields must be optional and should be ignored by clients and servers
-that do not understand them.
-
-<div id="since-v2.10"/>
-##Changes Since v2.10 ##
-
-* Add <tt>bindable</tt> field to [Plan Object](#PObject) to allow services to have both bindable and non-bindable plans.
-
-<div id="api-overview"/> 
-##API Overview 
+## API Overview
 
 The Service Broker API defines an HTTP interface between the services marketplace of a platform and service brokers.
 
@@ -53,7 +36,21 @@ What a binding represents may also vary by service. In general creation of a bin
 
 A platform marketplace may expose services from one or many service brokers, and an individual service broker may support one or many platform marketplaces using different URL prefixes and credentials.
 
-<div id="version-header"/>  
+## Changes
+
+### Change Policy
+
+* Existing endpoints and fields will not be removed or renamed.
+* New optional endpoints, or new HTTP methods for existing endpoints, may be
+added to enable support for new features.
+* New fields may be added to existing request/response messages.
+These fields must be optional and should be ignored by clients and servers
+that do not understand them.
+
+### Changes Since v2.10
+
+* Add <tt>bindable</tt> field to [Plan Object](#PObject) to allow services to have both bindable and non-bindable plans.
+
 ## API Version Header
 
 Requests from the platform to the service broker must contain a header that declares the version number of the Service Broker API that the marketplace will use:
@@ -64,14 +61,12 @@ The version numbers are in the format `MAJOR.MINOR`, using semantic versioning s
 
 This header allows brokers to reject requests from marketplaces for versions they do not support. While minor API revisions will always be additive, it is possible that brokers depend on a feature from a newer version of the API that is supported by the platform. In this scenario the broker may reject the request with `412 Precondition Failed` and provide a message that informs the operator of the required API version.
 
-<div id="authentication"/> 
 ## Authentication
 
 The marketplace must authenticate with the service broker using HTTP
 basic authentication (the `Authorization:` header) on every request. The broker is responsible for validating the username and password and returning a `401 Unauthorized` message if credentials are invalid. It is recommended that brokers support secure communication from platform marketplaces over TLS.
 
-<div id="catalog-mgmt"/>
-## Catalog Management 
+## Catalog Management
 
 The first endpoint that a broker must implement is the service catalog.
 
@@ -84,23 +79,23 @@ Warnings for broker authors:
 
 The following sections describe catalog requests and responses in the Service Broker API.
 
-### Request ###
+### Request
 
-#### Route ####
+#### Route
 `GET /v2/catalog`
 
-#### cURL ####
+#### cURL
 <pre class="terminal">
  $ curl -H "X-Broker-API-Version: 2.11" http://username:password@broker-url/v2/catalog
 </pre>
 
-### Response ###
+### Response
 
 | Status Code  | Description  |
 |---|---|
 | 200 OK  | The expected response body is below. |
 
-#### Body - Schema of Service Objects ####
+#### Body
 
 CLI and web clients have different needs with regard to service and plan names.
 A CLI-friendly string is all lowercase, with no spaces.
@@ -112,7 +107,7 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
 |---|---|---|
 |  services* |  array-of-service-objects |  Schema of service objects defined below. |
 
-##### Service Objects #####
+##### Service Objects
 
 |  Response field |  Type | Description  |
 |---|---|---|
@@ -127,7 +122,7 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
 | plan\_updateable  | boolean  |  Whether the service supports upgrade/downgrade for some plans. Please note that the misspelling of the attribute <code>plan\_updatable</code> to <code>plan\_updateable</code> was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility.  |
 | [plans*](#PObject) | array-of-objects | A list of plans for this service, schema is defined below.|  |
 
-##### Dashboard Client Object <a name="DObject"></a> #####
+##### Dashboard Client Object
 
 | Response field  | Type  | Description  |
 |---|---|---|
@@ -136,7 +131,7 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
 |  redirect_uri |  string | A URI for the service dashboard. Validated by the OAuth token server when the dashboard requests a token.  |
 
 
-##### Plan Object <a name="PObject"></a> #####
+##### Plan Object
 
 |  Response field | Type  | Description  |
 |---|---|---|
@@ -232,13 +227,11 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
 </pre>
 
 
-<div id="adding-broker-platform"/>
-### Adding a Broker to the Platform 
+### Adding a Broker to the Platform
 
 After implementing the first endpoint `GET /v2/catalog` documented [above](#catalog-mgmt), you must register the service broker with your platform to make your services and plans available to end users.
 
-<div id="synchronous-asynchronous"</a>
-## Synchronous and Asynchronous Operations 
+## Synchronous and Asynchronous Operations
 
 Broker clients expect prompt responses to all API requests in order to provide users with fast feedback. Service broker authors should implement their brokers to respond promptly to all requests but must decide whether to implement synchronous or asynchronous responses. Brokers that can guarantee completion of the requested operation with the response should return the synchronous response. Brokers that cannot guarantee completion of the operation with the response should implement the asynchronous response.
 
@@ -246,15 +239,13 @@ Providing a synchronous response for a provision, update, or bind operation befo
 
 Support for synchronous or asynchronous responses may vary by service offering, even by service plan.
 
-<div id="synchronous-operations"/>
-### Synchronous Operations 
+### Synchronous Operations
 
 To execute a request synchronously, the broker need only return the usual status codes: `201 CREATED` for provision and bind, and `200 OK` for update, unbind, and deprovision.
 
 Brokers that support sychronous responses for provision, update, and delete can ignore the `accepts_incomplete=true` query parameter if it is provided by the client.
 
-<div id="asynchronous-operations"/>
-### Asynchronous Operations 
+### Asynchronous Operations
 
 <p class='note'><strong>Note:</strong> Asynchronous operations are currently supported only for provision, update, and deprovision.</p>
 
@@ -271,23 +262,22 @@ If the query parameter described above is present, and the broker executes the r
 
 An asynchronous response triggers the platform marketplace to poll the endpoint `GET /v2/service_instances/:guid/last_operation` until the broker indicates that the requested operation has succeeded or failed. Brokers may include a status message with each response for the `last_operation` endpoint that provides visibility to end users as to the progress of the operation.
 
-#### Blocking Operations ####
+#### Blocking Operations
 
 The marketplace must ensure that service brokers do not receive requests for an instance while an asynchronous operation is in progress. For example, if a broker is in the process of provisioning an instance asynchronously, the marketplace must not allow any update, bind, unbind, or deprovision requests to be made through the platform. A user who attempts to perform one of these actions while an operation is already in progress must receive an HTTP 400 response with the error message: `Another operation for this service instance is in progress`.
 
-<div id="polling"/>
-## Polling Last Operation 
+## Polling Last Operation
 
 When a broker returns status code `202 ACCEPTED` for [provision](#provisioning), [update](#updating_service_instance), or [deprovision](#deprovisioning), the platform will begin polling the `/v2/service_instances/:guid/last_operation` endpoint to obtain the state of the last requested operation. The broker response must contain the field `state` and an optional field `description`.
 
 Valid values for `state` are `in progress`, `succeeded`, and `failed`. The platform will poll the `last_operation` endpoint as long as the broker returns `"state": "in progress"`. Returning `"state": "succeeded"` or `"state": "failed"` will cause the platform to cease polling. The value provided for `description` will be passed through to the platform API client and can be used to provide additional detail for users about the progress of the operation.
 
-### Request ###
+### Request
 
-##### Route #####
+#### Route
 `GET /v2/service_instances/:instance_id/last_operation`
 
-##### Parameters #####
+#### Parameters
 
 The request provides these query string parameters as useful hints for brokers.
 
@@ -299,12 +289,12 @@ The request provides these query string parameters as useful hints for brokers.
 
 <p class="note"><strong>Note:</strong> Although the request query parameters <code>service_id</code> and <code>plan_id</code> are not required, the platform should include them on all <code>last_operation</code> requests it makes to service brokers.</p>
 
-##### cURL #####
+#### cURL
 <pre class="terminal">
 $ curl http://username:password@broker-url/v2/service_instances/:instance_id/last_operation
 </pre>
 
-### Response ###
+### Response
 
 | Status Code  |  Description |
 |---|---|
@@ -313,7 +303,7 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id/las
 
 Responses with any other status code should be interpreted as an error or invalid response. The platform should continue polling until the broker returns a valid response or the [maximum polling duration](#polling-interval-and-duration) is reached. Brokers may use the `description` field to expose user-facing error messages about the operation state; for more info see [Broker Errors](#broker-errors).
 
-##### Body #####
+#### Body
 
 All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
 
@@ -333,24 +323,22 @@ For success responses, the following fields are valid.
 }
 </pre>
 
-<div id="polling-interval-and-duration"/>
 ### Polling Interval and Duration    
 
 The frequency and maximum duration of polling may vary by platform client. If a platform has a max polling duration and this limit is reached, the platform will cease polling and the operation state will be considered `failed`.
 
-<div id="provisioning"/> 
 ## Provisioning
 
 When the broker receives a provision request from the platform, it should take whatever action is necessary to create a new resource. What provisioning represents varies by service and plan, although there are several common use cases. For a MySQL service, provisioning could result in an empty dedicated database server running on its own VM or an empty schema on a shared database server. For non-data services, provisioning could just mean an account on an multi-tenant SaaS application.
 
-### Request ###
+### Request
 
-##### Route #####
+#### Route
 `PUT /v2/service_instances/:instance_id`
 
 The `:instance_id` of a service instance is provided by the platform. This ID will be used for future requests (bind and deprovision), so the broker must use it to correlate the resource it creates.
 
-##### Body #####
+#### Body
 | Request field  | Type  |  Description |
 |---|---|---|
 | service_id*  | string  | The ID of the service (from the catalog). Must be globally unique.  |
@@ -375,7 +363,7 @@ The `:instance_id` of a service instance is provided by the platform. This ID wi
 }
 </pre>
 
-##### cURL #####
+#### cURL
 <pre class="terminal">
 $ curl http://username:password@broker-url/v2/service_instances/:instance_id -d '{
   "service_id": "service-guid-here",
@@ -389,7 +377,7 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id -d 
 }' -X PUT -H "X-Broker-API-Version: 2.11" -H "Content-Type: application/json"
 </pre>
 
-### Response ###
+### Response
 
 | Status Code  | Description  |
 |---|---|
@@ -402,7 +390,7 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id -d 
 
 Responses with any other status code will be interpreted as a failure. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
-##### Body #####
+#### Body
 
 All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
 
@@ -422,8 +410,7 @@ For success responses, a broker may return the following fields. For error respo
 }
 </pre>
 
-<div id="updating_service_instance"/>
-## Updating a Service Instance 
+## Updating a Service Instance
 
 By implementing this endpoint, service broker authors can enable users to modify two attributes of an existing service instance: the service plan and parameters. By changing the service plan, users can upgrade or downgrade their service instance to other plans. By modifying properties, users can change configuration options that are specific to a service or plan.
 
@@ -431,14 +418,14 @@ To enable support for the update of the plan, a broker should declare support pe
 
 Not all permutations of plan changes are expected to be supported. For example, a service may support upgrading from plan "shared small" to "shared large" but not to plan "dedicated". It is up to the broker to validate whether a particular permutation of plan change is supported. If a particular plan change is not supported, the broker should return a meaningful error message in response.
 
-### Request ###
+### Request
 
-##### Route #####
+#### Route
 `PATCH /v2/service_instances/:instance_id`
 
 `:instance_id` is the global unique ID of a previously-provisioned service instance.
 
-##### Body #####
+#### Body
 
 | Request Field  | Type  |  Description |
 |---|---|---|
@@ -471,7 +458,7 @@ Not all permutations of plan changes are expected to be supported. For example, 
 }
 </pre>
 
-##### cURL #####
+#### cURL
 <pre class="terminal">
 $ curl http://username:password@broker-url/v2/service_instances/:instance_id -d '{
   "service_id": "service-guid-here",
@@ -489,7 +476,7 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id -d 
 }' -X PATCH -H "X-Broker-API-Version: 2.11" -H "Content-Type: application/json"
 </pre>
 
-### Response ###
+### Response
 
 | Status Code  | Description  |
 |---|---|
@@ -499,7 +486,7 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id -d 
 
 Responses with any other status code will be interpreted as a failure. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
-##### Body #####
+#### Body
 
 All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
 
@@ -518,19 +505,17 @@ For success responses, a broker may return the following field. Others will be i
 </pre>
 
 
-<div id="binding"/>
-## Binding 
+## Binding
 
-If `bindable:true` is declared for a service or plan in the [Catalog](#catalog-mgmt) endpoint, broker clients may request generation of a service binding. 
+If `bindable:true` is declared for a service or plan in the [Catalog](#catalog-mgmt) endpoint, broker clients may request generation of a service binding.
 
 <p class="note"><strong>Note</strong>: Not all services must be bindable --- some deliver value just from being provisioned. Brokers that offer services that are bindable should declare them as such using <code>bindable: true</code> in the <a href="#catalog-mgmt">Catalog</a>. Brokers that do not offer any bindable services do not need to implement the endpoint for bind requests.</p>
 
-<div id="types-of-binding"/>
-### Types of Binding 
+### Types of Binding
 
 #### Credentials ####
 
-Credentials are a set of information used by an application or a user to utilize the service instance. If the broker supports generation of credentials it should return `credentials` in the response for a request to create a service binding. Credentials should be unique whenever possible, so access can be revoked for each binding without affecting consumers of other bindings for the service instance. 
+Credentials are a set of information used by an application or a user to utilize the service instance. If the broker supports generation of credentials it should return `credentials` in the response for a request to create a service binding. Credentials should be unique whenever possible, so access can be revoked for each binding without affecting consumers of other bindings for the service instance.
 
 #### Log Drain ####
 
@@ -538,30 +523,29 @@ There are a class of service offerings that provide aggregation, indexing, and a
 
 The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate a response for create binding that includes a `syslog_drain_url`. Platform marketplaces should consider a broker's response invalid if it includes a `syslog_drain_url` and `"requires":["syslog_drain"]` is not present in the [Catalog](#catalog-mgmt) endpoint.
 
-<div id= "route_services"/>
-#### Route Services 
+#### Route Services
 
 There are a class of service offerings that intermediate requests to applications, performing functions such as rate limiting or authorization. To configure a service instance with behavior specific to an application's routable address, a broker client may send the address along with the request to create a binding using `"bind_resource":{"route":"some-address.com"}`.
 
-Some platforms may support proxying of application requests to service instances. In this case the platform needs to know where to send application requests; to facilitate this, the broker may return a `route_service_url` in the response for a request to create a binding. Not all services of this type expect to receive requests proxied by the platform; some services will have been configured out-of-band to intermediate requests to applications. In this case, the broker will not return `route_service_url` in response to the create binding request. By sending `bind-resource` as described above, the platform enables dynamic configuration of a service instance already in the application request path for the route, requiring no change in the platform routing tier. 
+Some platforms may support proxying of application requests to service instances. In this case the platform needs to know where to send application requests; to facilitate this, the broker may return a `route_service_url` in the response for a request to create a binding. Not all services of this type expect to receive requests proxied by the platform; some services will have been configured out-of-band to intermediate requests to applications. In this case, the broker will not return `route_service_url` in response to the create binding request. By sending `bind-resource` as described above, the platform enables dynamic configuration of a service instance already in the application request path for the route, requiring no change in the platform routing tier.
 
 The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate requests to create bindings. A platform may opt to reject requests to create bindings when a broker has declared `"requires":["route_forwarding"]` for a service in the catalog endpoint.
 
 #### Volume Services ####
 
-There are a class of services that provide network storage to applications via volume mounts in the application container. A service broker may return data required for this configuration with `volume_mount` in response to the request to create a binding. 
+There are a class of services that provide network storage to applications via volume mounts in the application container. A service broker may return data required for this configuration with `volume_mount` in response to the request to create a binding.
 
 The `requires` field in the [Catalog](#catalog-mgmt) endpoint enables a platform marketplace to validate a response for create binding that includes a `volume_mounts`. Platform marketplaces should consider a broker's response invalid if it includes a `volume_mounts` and `"requires":["volume_mount"]` is not present in the [Catalog](#catalog-mgmt) endpoint.
 
-### Request ###
+### Request
 
-##### Route #####
+#### Route
 `PUT /v2/service_instances/:instance_id/service_bindings/:binding_id`
 
 The `:instance_id` is the ID of a previously-provisioned service instance. The `:binding_id` is also provided by the platform. This ID will be used for future unbind requests, so the broker must use it to correlate
 the resource it creates.
 
-##### Body #####
+#### Body
 
 | Request Field  | Type  | Description  |
 |---|---|---|
@@ -588,7 +572,7 @@ the resource it creates.
 </pre>
 
 
-##### cURL #####
+#### cURL
 <pre class="terminal">
 $ curl http://username:password@broker-url/v2/service_instances/:instance_id/service_bindings/:binding_id -d '{
   "service_id": "service-guid-here",
@@ -603,7 +587,7 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id/ser
 }' -X PUT
 </pre>
 
-### Response ###
+### Response
 
 | Status Code  | Description  |
 |---|---|
@@ -614,7 +598,7 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id/ser
 
 Responses with any other status code will be interpreted as a failure and an unbind request will be sent to the broker to prevent an orphan being created on the broker. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
-##### Body #####
+#### Body
 
 All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
 
@@ -640,8 +624,7 @@ For success responses, the following fields are supported. Others will be ignore
     }
 </pre>
 
-<div id="unbinding"/>
-## Unbinding 
+## Unbinding
 
 <p class="note"><strong>Note</strong>: Brokers that do not provide any bindable services or plans do not need to implement this endpoint.</p>
 
@@ -649,12 +632,12 @@ When a broker receives an unbind request from the marketplace, it should delete 
 
 ### Request ###
 
-##### Route #####
+#### Route
 `DELETE /v2/service_instances/:instance_id/service_bindings/:binding_id`
 
 The `:instance_id` is the ID of a previously-provisioned service instance. The `:binding_id` is the ID of a previously provisioned binding for that instance.
 
-##### Parameters #####
+#### Parameters
 
 The request provides these query string parameters as useful hints for brokers.
 
@@ -665,13 +648,13 @@ The request provides these query string parameters as useful hints for brokers.
 
 \* Query parameters with an asterisk are required.
 
-##### cURL #####
+#### cURL
 <pre class="terminal">
 $ curl 'http://username:password@broker-url/v2/service_instances/:instance_id/
   service_bindings/:binding_id?service_id=service-id-here&plan_id=plan-id-here' -X DELETE -H "X-Broker-API-Version: 2.11"
 </pre>
 
-### Response ###
+### Response
 
 | Status Code  | Description  |
 |---|---|
@@ -680,28 +663,27 @@ $ curl 'http://username:password@broker-url/v2/service_instances/:instance_id/
 
 Responses with any other status code will be interpreted as a failure and the binding will remain in the marketplace database. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
-##### Body #####
+#### Body
 
 All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
 
 For a success response, the expected response body is `{}`.
 
-<div id="deprovisioning"/>
-## Deprovisioning 
+## Deprovisioning
 
 When a broker receives a deprovision request from the marketplace, it should
 delete any resources it created during the provision.
 Usually this means that all resources are immediately reclaimed for future
 provisions.
 
-### Request ###
+### Request
 
-##### Route #####
+#### Route
 `DELETE /v2/service_instances/:instance_id`
 
 `:instance_id` is the identifier of a previously provisioned instance.
 
-##### Parameters #####
+#### Parameters
 
 The request provides these query string parameters as useful hints for brokers.
 
@@ -713,13 +695,13 @@ The request provides these query string parameters as useful hints for brokers.
 
 \* Query parameters with an asterisk are required.
 
-##### cURL #####
+#### cURL
 <pre class="terminal">
 $ curl 'http://username:password@broker-url/v2/service_instances/:instance_id?service_id=
     service-id-here&plan_id=plan-id-here' -X DELETE -H "X-Broker-API-Version: 2.11"
 </pre>
 
-### Response ###
+### Response
 
 | Status Code | Description |
 |---|---|
@@ -730,7 +712,7 @@ $ curl 'http://username:password@broker-url/v2/service_instances/:instance_id?se
 
 Responses with any other status code will be interpreted as a failure and the service instance will remain in the marketplace database. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
 
-##### Body #####
+#### Body
 
 All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
 
@@ -749,16 +731,15 @@ For success responses, the following fields are supported. Others will be ignore
 }
 </pre>
 
-<div id="broker-errors"/>
-## Broker Errors 
+## Broker Errors
 
-### Response ###
+### Response
 
 Broker failures beyond the scope of the well-defined HTTP response codes listed
 above (like 410 on delete) should return an appropriate HTTP response code
 (chosen to accurately reflect the nature of the failure) and a body containing a valid JSON Object (not an array).
 
-##### Body #####
+#### Body
 
 All response bodies must be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body may or may not be returned.
 
@@ -774,14 +755,13 @@ For error responses, the following fields are valid. Others will be ignored. If 
 }
 </pre>
 
-<div id="orphans"/> 
 ## Orphans
 
 The platform marketplace is the source of truth for service instances and bindings. Service brokers are expected to have successfully provisioned all the instances and bindings that the marketplace knows about, and none that it doesn't.
 
 Orphans can result if the broker does not return a response before a request from the marketplace times out (typically 60 seconds). For example, if a broker does not return a response to a provision request before the request times out, the broker might eventually succeed in provisioning an instance after the marketplace considers the request a failure. This results in an orphan instance on the broker's side.
 
-To mitigate orphan instances and bindings, the marketplace should attempt to delete resources it cannot be sure were successfully created, and should keep trying to delete them until the broker responds with a success. 
+To mitigate orphan instances and bindings, the marketplace should attempt to delete resources it cannot be sure were successfully created, and should keep trying to delete them until the broker responds with a success.
 
 Platforms should initiate orphan mitigation in the following scenarios:
 

--- a/spec.md
+++ b/spec.md
@@ -1,11 +1,10 @@
 # Open Service Broker API v2.11
 
 ## Table of Contents
-  - [API Release Notes](#release-notes)
+  - [API Overview](#api-overview)
   - [Changes](#changes)
     - [Change Policy](#change-policy)
     - [Changes Since v2.10](#since-v2.10)
-  - [API Overview](#api-overview)
   - [API Version Header](#version-header)
   - [Authentication](#authentication)
   - [Catalog Management](#catalog-mgmt)


### PR DESCRIPTION
- consistency of headings
- moved overview to top
- added missing spec for volume mounts field in bind response