### PR TITLE
Fix master - some checks were failing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/openservicebrokerapi/servicebroker.svg?branch=master)](https://travis-ci.org/openservicebrokerapi/servicebroker "Travis")
+
 ![Open Service Broker API](https://openservicebrokerapi.org/wp-content/uploads/sites/21/2016/12/osbapi_logo_concept3_wtm.png)
 
 ## Latest Release: v2.12

--- a/profile.md
+++ b/profile.md
@@ -4,7 +4,7 @@
 
 The [Open Service Broker API specification](spec.md) allows for extensions
 and variations based on the environments in which it is being used; this
-document contains the recommended usage pattern for some of those variants.
+document contains the suggested usage pattern for some of those variants.
 
 ## Table of Contents
 

--- a/spec.md
+++ b/spec.md
@@ -745,7 +745,7 @@ For success responses, the following fields are supported. Others will be ignore
 | driver* | string | Name of the volume driver plugin which manages the device. |
 | container_dir* | string | The path in the application container onto which the volume will be mounted. This specification does not mandate what action the platform is to take if the path specified already exists in the container. |
 | mode* | string | "r" to mount the volume read-only or "rw" to mount it read-write. |
-| device_type* | string | A string specifying the type of device to mount. Currently the only supported value is "shared".  |
+| device_type* | string | A string specifying the type of device to mount. Currently the only supported value is "shared". |
 | device* | device-object | Device object containing device_type specific details. Currently only shared devices are supported. |
 
 ##### Device Object

--- a/tools/verify-all.sh
+++ b/tools/verify-all.sh
@@ -34,9 +34,9 @@ echo Verifying hrefs
 "${REPODIR}/tools/verify-links.sh" -v "${REPODIR}" || rc=1
 
 echo Verify RFC2119 keywords
-"${REPODIR}/tools/verify-rfc.sh" -v "${REPODIR}"/spec.md || rc=1
+"${REPODIR}/tools/verify-rfc.sh" -v "${REPODIR}"/spec.md "${REPODIR}"/profile.md|| rc=1
 
 echo Verify tables
-"${REPODIR}/tools/verify-tables.sh" "${REPODIR}/spec.md" || rc=1
+"${REPODIR}/tools/verify-tables.sh" "${REPODIR}/spec.md" "${REPODIR}"/profile.md || rc=1
 
 exit $rc

--- a/tools/verify-links.sh
+++ b/tools/verify-links.sh
@@ -123,9 +123,9 @@ for file in ${mdFiles}; do
 
     # An external href (ie. starts with http)
     if [ "${ref:0:4}" == "http" ]; then
-      if ! wget --no-check-certificate --timeout=10 -O /dev/null ${ref} \
+      if ! curl -f -s -k --connect-timeout 10 ${ref} \
           > /dev/null 2>&1 ; then
-        echo $file: Can\'t load: url ${ref} | tee -a ${tmp}3
+        echo $file: Can\'t load url: ${ref} | tee -a ${tmp}3
       fi
       continue
     fi

--- a/tools/verify-tables.sh
+++ b/tools/verify-tables.sh
@@ -79,7 +79,7 @@ function checkForPunc() {
     return 0
   fi
 
-  echo "$file - $1: Last column doesn't end with a '.' or '?'"
+  echo "$file - $1: Last column doesn't end with a '. |' or '? |' - watch for extra spaces"
   return 1
 }
 


### PR DESCRIPTION
- extra spaces in one row in a table
- profile.md wasn't being checked for rfc keywords and table layouts
- fix an rfc keyword usage in profile.md
- make check msg a bit better
- add travis build badge to README so we know when master is failing
- fix a bug in the tool - sometimes wget would do weird stuff, use curl instead

Signed-off-by: Doug Davis <dug@us.ibm.com>