### PR TITLE
Add Matt McNeeney to the PMC

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -15,3 +15,4 @@ reviewers:
     - fmui
     - zrob
     - avade
+    - mattmcneeney


### PR DESCRIPTION
Matt has been voted in and will join the OSBAPI PMC as a dedicated committer.