### PR TITLE
add context object to binding calls

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -130,6 +130,7 @@ The following table specifies which properties MUST appear in each API:
 | --- | --- |
 | `PUT /v2/service_instances/:instance_id` | `organization_guid`<br>`space_guid` |
 | `PATCH /v2/service_instances/:instance_id` | `organization_guid`<br>`space_guid` |
+| `PUT /v2/service_instances/:instance_id/service_bindings/:binding_id` | `organization_guid`<br>`space_guid` |
 
 Example:
 
@@ -168,6 +169,7 @@ The following table specifies which properties MUST appear in each API:
 | --- | --- |
 | `PUT /v2/service_instances/:instance_id` | `namespace` |
 | `PATCH /v2/service_instances/:instance_id` | `namespace` |
+| `PUT /v2/service_instances/:instance_id/service_bindings/:binding_id` | `namespace` |
 
 Example:
 

--- a/spec.md
+++ b/spec.md
@@ -795,6 +795,7 @@ it to correlate the resource it creates.
 
 | Request Field | Type | Description |
 | --- | --- | --- |
+| context | object | Contextual data under which the service binding is created. |
 | service_id* | string | ID of the service from the catalog. MUST be a non-empty string. |
 | plan_id* | string | ID of the plan from the catalog. MUST be a non-empty string. |
 | app_guid | string | Deprecated in favor of `bind_resource.app_guid`. GUID of an application associated with the binding to be created. If present, MUST be a non-empty string. |
@@ -828,6 +829,10 @@ binding requests.
 
 ```
 {
+  "context": {
+    "platform": "cloudfoundry",
+    "some_field": "some-contextual-data"
+  },
   "service_id": "service-id-here",
   "plan_id": "plan-id-here",
   "bind_resource": {
@@ -844,6 +849,10 @@ binding requests.
 #### cURL
 ```
 $ curl http://username:password@broker-url/v2/service_instances/:instance_id/service_bindings/:binding_id -d '{
+  "context": {
+    "platform": "cloudfoundry",
+    "some_field": "some-contextual-data"
+  },
   "service_id": "service-id-here",
   "plan_id": "plan-id-here",
   "bind_resource": {


### PR DESCRIPTION
We have some use cases where knowing contextual information would be useful when creating a service binding.

What do y'all think of this?