### PR TITLE
Add text around what to do on a deprovision when there are bindings

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1021,6 +1021,11 @@ delete any resources it created during the provision.
 Usually this means that all resources are immediately reclaimed for future
 provisions.
 
+Platforms MUST delete all bindings for a service prior
+to attempting to deprovision the service. This specification does not
+specify what a broker is to do if it receives a deprovision request
+while there are still bindings associated with it.
+
 ### Request
 
 #### Route


### PR DESCRIPTION
Closes #127

Basic does this:
- clarify in the spec that it is RECOMMENDED that platforms delete all Bindings prior to deleting an Instance
- brokers MAY support deleting an Instance that still has bindings (causing a cascading delete), but if they don't then we'll specify the exact error that MUST be returned
- platforms MAY attempt to delete an Instance that still has Bindings, but if they get the well defined error then they MUST delete the bindings first.

Signed-off-by: Doug Davis <dug@us.ibm.com>