### PR TITLE
Making headers for version more consistent.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -249,7 +249,7 @@ The following HTTP Headers are defined for this operation:
 
 #### cURL
 ```
-$ curl -H "X-Broker-API-Version: 2.12" http://username:password@broker-url/v2/catalog
+$ curl http://username:password@broker-url/v2/catalog -H "X-Broker-API-Version: 2.12"
 ```
 
 ### Response
@@ -571,7 +571,7 @@ The following HTTP Headers are defined for this operation:
 
 #### cURL
 ```
-$ curl http://username:password@broker-url/v2/service_instances/:instance_id/last_operation
+$ curl http://username:password@broker-url/v2/service_instances/:instance_id/last_operation -H "X-Broker-API-Version: 2.12"
 ```
 
 ### Response
@@ -990,7 +990,7 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id/ser
     "parameter1-name-here": 1,
     "parameter2-name-here": "parameter2-value-here"
   }
-}' -X PUT
+}' -X PUT -H "X-Broker-API-Version: 2.12" -H "Content-Type: application/json"
 ```
 
 ### Response

--- a/spec.md
+++ b/spec.md
@@ -582,7 +582,7 @@ The following HTTP Headers are defined for this operation:
 
 #### cURL
 ```
-$ curl http://username:password@broker-url/v2/service_instances/:instance_id/last_operation -H "X-Broker-API-Version: 2.12"
+$ curl http://username:password@broker-url/v2/service_instances/:instance_id/last_operation -H "X-Broker-API-Version: 2.13"
 ```
 
 ### Response
@@ -1001,7 +1001,7 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id/ser
     "parameter1-name-here": 1,
     "parameter2-name-here": "parameter2-value-here"
   }
-}' -X PUT -H "X-Broker-API-Version: 2.12" -H "Content-Type: application/json"
+}' -X PUT -H "X-Broker-API-Version: 2.13" -H "Content-Type: application/json"
 ```
 
 ### Response


### PR DESCRIPTION
The spec does not use headers in the cURL examples in a consistent way, fixed this.