### PR TITLE
Update 'broker' to 'service broker' to be specific in the spec.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -11,7 +11,7 @@
   - [URL Properties](#url-properties)
   - [Originating Identity](#originating-identity)
   - [Catalog Management](#catalog-management)
-    - [Adding a Broker to the Platform](#adding-a-broker-to-the-platform)
+    - [Adding a Service Broker to the Platform](#adding-a-service-broker-to-the-platform)
   - [Synchronous and Asynchronous Operations](#synchronous-and-asynchronous-operations)
     - [Synchronous Operations](#synchronous-operations)
     - [Asynchronous Operations](#asynchronous-operations)
@@ -23,20 +23,32 @@
     - [Types of Binding](#types-of-binding)
   - [Unbinding](#unbinding)
   - [Deprovisioning](#deprovisioning)
-  - [Broker Errors](#broker-errors)
+  - [Service Broker Errors](#service-broker-errors)
   - [Orphans](#orphans)
 
 ## API Overview
 
-The Service Broker API defines an HTTP interface between the services marketplace of a platform and service brokers.
+The Service Broker API defines an HTTP interface between the services
+marketplace of a platform and service brokers.
 
-The service broker is the component of the service that implements the Service Broker API, for which a platform's marketplace is a client. Service brokers are responsible for advertising a catalog of service offerings and service plans to the marketplace, and acting on requests from the marketplace for provisioning, binding, unbinding, and deprovisioning.
+The service broker is the component of the service that implements the Service
+Broker API, for which a platform's marketplace is a client. Service brokers
+are responsible for advertising a catalog of service offerings and service
+plans to the marketplace, and acting on requests from the marketplace for
+provisioning, binding, unbinding, and deprovisioning.
 
-In general, provisioning reserves a resource on a service; we call this reserved resource a service instance. What a service instance represents can vary by service. Examples include a single database on a multi-tenant server, a dedicated cluster, or an account on a web application.
+In general, provisioning reserves a resource on a service; we call this
+reserved resource a service instance. What a service instance represents can
+vary by service. Examples include a single database on a multi-tenant server,
+a dedicated cluster, or an account on a web application.
 
-What a binding represents MAY also vary by service. In general creation of a binding either generates credentials necessary for accessing the resource or provides the service instance with information for a configuration change.
+What a binding represents MAY also vary by service. In general creation of a
+binding either generates credentials necessary for accessing the resource or
+provides the service instance with information for a configuration change.
 
-A platform marketplace MAY expose services from one or many service brokers, and an individual service broker MAY support one or many platform marketplaces using different URL prefixes and credentials.
+A platform marketplace MAY expose services from one or many service brokers,
+and an individual service broker MAY support one or many platform marketplaces
+using different URL prefixes and credentials.
 
 ## Notations and Terminology
 
@@ -89,7 +101,7 @@ that do not understand them.
 ### Changes Since v2.12
 
 * Added [`schemas`](https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/spec.md#schema-object)
-  field to services in the catalog that brokers can use to declare the
+  field to services in the catalog that service brokers can use to declare the
   configuration parameters their service accepts for creating a service
   instance, updating a service instance and creating a service binding.
 * Added [`context`](https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/spec.md#binding)
@@ -112,29 +124,39 @@ For changes in older versions, see the [release notes](https://github.com/opense
 
 ## API Version Header
 
-Requests from the platform to the service broker MUST contain a header that declares the version number of the Service Broker API that the marketplace will use:
+Requests from the platform to the service broker MUST contain a header that
+declares the version number of the Service Broker API that the marketplace
+will use:
 
 `X-Broker-API-Version: 2.13`
 
 The version numbers are in the format `MAJOR.MINOR` using semantic versioning.
 
-This header allows brokers to reject requests from marketplaces for versions they do not support. While minor API revisions will always be additive, it is possible that brokers depend on a feature from a newer version of the API that is supported by the platform. In this scenario the broker MAY reject the request with `412 Precondition Failed` and provide a message that informs the operator of the API version that is to be used instead.
+This header allows service brokers to reject requests from marketplaces for
+versions they do not support. While minor API revisions will always be
+additive, it is possible that service brokers depend on a feature from a newer
+version of the API that is supported by the platform. In this scenario the
+service broker MAY reject the request with `412 Precondition Failed` and
+provide a message that informs the operator of the API version that is to be
+used instead.
+
+
 
 ## Authentication
 
-While the communication between a platform and broker
-MAY be unsecure, it is RECOMMENDED that all communications between a
-platform and a broker are secured via TLS and authenticated.
+While the communication between a platform and service broker MAY be unsecure,
+it is RECOMMENDED that all communications between a platform and a service
+broker are secured via TLS and authenticated.
 
 Unless there is some out of band communication and agreement between a
 platform and a service broker, the marketplace MUST authenticate with the
 service broker using HTTP basic authentication (the `Authorization:` header)
-on every request. This specification does not specify how platform and brokers
-agree on other methods of authentication.
+on every request. This specification does not specify how platform and service
+brokers agree on other methods of authentication.
 
-If authentication is used, the broker MUST authenticate the request using the
-predetermined authentication mechanism and MUST return a `401 Unauthorized`
-response if the authentication fails.
+If authentication is used, the service broker MUST authenticate the request
+using the predetermined authentication mechanism and MUST return a `401
+Unauthorized` response if the authentication fails.
 
 Note: Using an authentication mechanism that is agreed to via out of band
 communications could lead to interoperability issues with other platforms.
@@ -149,25 +171,25 @@ URLs:
 - `binding_id`
 - `operation`
 
-While this specification places no restriction on the set of characters used
+While this specification places no restriction on the set of characters use
 within these strings, it is RECOMMENDED that these properties only contain
 characters from the "Unreserved Characters" as defined by
 [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.3). In other words:
 uppercase and lowercase letters, decimal digits, hyphen, period, underscore
 and tilde.
 
-If a character outside of the "Unreserved Characters" set is used, then
-it SHOULD be percent-encoded prior to being used as part of the HTTP request,
-per [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.1).
+If a character outside of the "Unreserved Characters" set is used, then it
+SHOULD be percent-encoded prior to being used as part of the HTTP request, per
+[RFC3986](https://tools.ietf.org/html/rfc3986#section-2.1).
 
 ## Originating Identity
 
 Often a service broker will need to know the identity of the user that
-initiated the request from the platform. For example, this might be needed
-for auditing or authorization purposes. In order to facilitate this, the
-platform will need to provide this identification information to the broker
-on each request. Platforms MAY support this feature, and if they do, they
-MUST adhere to the following:
+initiated the request from the platform. For example, this might be needed for
+auditing or authorization purposes. In order to facilitate this, the platform
+will need to provide this identification information to the service broker on
+each request. Platforms MAY support this feature, and if they do, they MUST
+adhere to the following:
 - For any OSB API request that is the result of an action taken by
   a platform's user, there MUST be an associated `OriginatingIdentity` header
   on that HTTP request.
@@ -206,39 +228,42 @@ Where the `value`, when decoded, is:
 }
 ```
 
-Note that not all messages sent to a broker are initiated by an end-user
-of the platform. For example, during orphan mitigation or during the
-querying of the broker's catalog, the platform might not have an end-user
-with which to associate the request, therefore in those cases the
+Note that not all messages sent to a service broker are initiated by an
+end-user of the platform. For example, during orphan mitigation or during the
+querying of the service broker's catalog, the platform might not have an
+end-user with which to associate the request, therefore in those cases the
 originating identity header would not be included in those messages.
+
 
 ## Catalog Management
 
-The first endpoint that a platform will interact with on the broker is the
-service catalog (`/v2/catalog`). This endpoint returns a list of all services
-available on the broker. Platforms query this endpoint from all brokers
-in order to present an aggregated user-facing catalog.
+The first endpoint that a platform will interact with on the service broker is
+the service catalog (`/v2/catalog`). This endpoint returns a list of all
+services available on the service broker. Platforms query this endpoint from
+all service brokers in order to present an aggregated user-facing catalog.
 
 Periodically, a platform MAY re-query the service catalog endpoint for a
-broker to see if there are any changes to the list of services. Brokers
-MAY add, remove or modify (metadata, plans, etc.) the list of services
-from previous queries.
+service broker to see if there are any changes to the list of services.
+Service brokers MAY add, remove or modify (metadata, plans, etc.) the list of
+services from previous queries.
 
-When determining what, if anything, has changed on a broker, the platform
-will use the `id` of the resources (services or plans) as the only immutable
-property and MUST use that to locate the same resource as was returned from
-a previous query. Likewise, a broker MUST NOT change the `id` of a resource
-across queries, otherwise a platform will treat it as a different resource.
+When determining what, if anything, has changed on a service broker, the
+platform will use the `id` of the resources (services or plans) as the only
+immutable property and MUST use that to locate the same resource as was
+returned from a previous query. Likewise, a service broker MUST NOT change the
+`id` of a resource across queries, otherwise a platform will treat it as a
+different resource.
 
 When a platform receives different `id` values for the same type of resource,
 even if all of the other metadata in those resources are the exact same, it
 MUST treat them as separate instances of that resource.
 
-Broker authors are expected to be cautious when removing services and plans
-from their catalogs, as platforms might have provisioned service instances of
-these plans. For example, platforms might restrict the actions that users
-can perform on existing service instances if the associated service or
-plan is deleted. Consider your deprecation strategy.
+Service broker authors are expected to be cautious when removing services and
+plans from their catalogs, as platforms might have provisioned service
+instances of these plans. For example, platforms might restrict the actions
+that users can perform on existing service instances if the associated service
+or plan is deleted. Consider your deprecation strategy.
+
 
 The following sections describe catalog requests and responses in the Service
 Broker API.
@@ -260,7 +285,7 @@ The following HTTP Headers are defined for this operation:
 
 #### cURL
 ```
-$ curl http://username:password@broker-url/v2/catalog -H "X-Broker-API-Version: 2.13"
+$ curl http://username:password@service-broker-url/v2/catalog -H "X-Broker-API-Version: 2.13"
 ```
 
 ### Response
@@ -286,12 +311,12 @@ A web-friendly display name is camel-cased with spaces and punctuation supported
 | Response field | Type | Description |
 | --- | --- | --- |
 | name* | string | A CLI-friendly name of the service. MUST only contain lowercase characters, numbers and hyphens (no spaces). MUST be unique across all service objects returned in this response. MUST be a non-empty string. |
-| id* | string | An identifier used to correlate this service in future requests to the broker. This MUST be globally unique. MUST be a non-empty string. Using a GUID is RECOMMENDED. |
+| id* | string | An identifier used to correlate this service in future requests to the service broker. This MUST be globally unique. MUST be a non-empty string. Using a GUID is RECOMMENDED. |
 | description* | string | A short description of the service. MUST be a non-empty string. |
 | tags | array-of-strings | Tags provide a flexible mechanism to expose a classification, attribute, or base technology of a service, enabling equivalent services to be swapped out without changes to dependent logic in applications, buildpacks, or other services. E.g. mysql, relational, redis, key-value, caching, messaging, amqp. |
 | requires | array-of-strings | A list of permissions that the user would have to give the service, if they provision it. The only permissions currently supported are `syslog_drain`, `route_forwarding` and `volume_mount`. |
 | bindable* | boolean | Specifies whether service instances of the service can be bound to applications. This specifies the default for all plans of this service. Plans can override this field (see [Plan Object](#plan-object)). |
-| metadata | JSON object | An opaque object of metadata for a service offering. Controller treats this as a blob. Note that there are [conventions](profile.md#service-metadata) in existing brokers and controllers for fields that aid in the display of catalog data. |
+| metadata | JSON object | An opaque object of metadata for a service offering. Controller treats this as a blob. Note that there are [conventions](profile.md#service-metadata) in existing service brokers and controllers for fields that aid in the display of catalog data. |
 | [dashboard_client](#dashboard-client-object) | object | Contains the data necessary to activate the Dashboard SSO feature for this service. |
 | plan_updateable | boolean | Whether the service supports upgrade/downgrade for some plans. Please note that the misspelling of the attribute `plan_updatable` as `plan_updateable` was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility. Defaults to false. |
 | [plans*](#plan-object) | array-of-objects | A list of plans for this service, schema is defined below. MUST contain at least one plan. |
@@ -318,10 +343,10 @@ how platforms might expose these values to their users.
 
 | Response field | Type | Description |
 | --- | --- | --- |
-| id* | string | An identifier used to correlate this plan in future requests to the broker. This MUST be globally unique. MUST be a non-empty string. Using a GUID is RECOMMENDED. |
+| id* | string | An identifier used to correlate this plan in future requests to the service broker. This MUST be globally unique. MUST be a non-empty string. Using a GUID is RECOMMENDED. |
 | name* | string | The CLI-friendly name of the plan. MUST only contain lowercase characters, numbers and hyphens (no spaces). MUST be unique within the service. MUST be a non-empty string. |
 | description* | string | A short description of the plan. MUST be a non-empty string. |
-| metadata | JSON object | An opaque object of metadata for a service plan. Controller treats this as a blob. Note that there are [conventions](profile.md#service-metadata) in existing brokers and controllers for fields that aid in the display of catalog data. |
+| metadata | JSON object | An opaque object of metadata for a service plan. Controller treats this as a blob. Note that there are [conventions](profile.md#service-metadata) in existing service brokers and controllers for fields that aid in the display of catalog data. |
 | free | boolean | When false, service instances of this plan have a cost. The default is true. |
 | bindable | boolean | Specifies whether service instances of the service plan can be bound to applications. This field is OPTIONAL. If specified, this takes precedence over the `bindable` attribute of the service. If not specified, the default is derived from the service. |
 | [schemas](#schema-object) | object | Schema definitions for service instances and bindings for the plan. |
@@ -494,29 +519,53 @@ schema being used.
 ```
 
 
-### Adding a Broker to the Platform
+### Adding a Service Broker to the Platform
 
-After implementing the first endpoint `GET /v2/catalog` documented [above](#catalog-management), the service broker will need to be registered with your platform to make your services and plans available to end users.
+After implementing the first endpoint `GET /v2/catalog` documented
+[above](#catalog-management), the service broker will need to be registered
+with your platform to make your services and plans available to end users.
 
 ## Synchronous and Asynchronous Operations
 
-Platforms expect prompt responses to all API requests in order to provide users with fast feedback. Service broker authors SHOULD implement their brokers to respond promptly to all requests but will need to decide whether to implement synchronous or asynchronous responses. Brokers that can guarantee completion of the requested operation with the response SHOULD return the synchronous response. Brokers that cannot guarantee completion of the operation with the response SHOULD implement the asynchronous response.
+Platforms expect prompt responses to all API requests in order to provide
+users with fast feedback. Service broker authors SHOULD implement their
+service brokers to respond promptly to all requests but will need to decide
+whether to implement synchronous or asynchronous responses. Service brokers
+that can guarantee completion of the requested operation with the response
+SHOULD return the synchronous response. Service brokers that cannot guarantee
+completion of the operation with the response SHOULD implement the
+asynchronous response.
 
-Providing a synchronous response for a provision, update, or bind operation before actual completion causes confusion for users as their service might not be usable and they have no way to find out when it will be. Asynchronous responses set expectations for users that an operation is in progress and can also provide updates on the status of the operation.
+Providing a synchronous response for a provision, update, or bind operation
+before actual completion causes confusion for users as their service might not
+be usable and they have no way to find out when it will be. Asynchronous
+responses set expectations for users that an operation is in progress and can
+also provide updates on the status of the operation.
 
-Support for synchronous or asynchronous responses MAY vary by service offering, even by service plan.
+Support for synchronous or asynchronous responses MAY vary by service
+offering, even by service plan.
 
 ### Synchronous Operations
 
-To execute a request synchronously, the broker need only return the usual status codes: `201 Created` for provision and bind, and `200 OK` for update, unbind, and deprovision.
+To execute a request synchronously, the service broker need only return the
+usual status codes: `201 Created` for provision and bind, and `200 OK` for
+update, unbind, and deprovision.
 
-Brokers that support synchronous responses for provision, update, and delete can ignore the `accepts_incomplete=true` query parameter if it is provided by the client.
+Service brokers that support synchronous responses for provision, update, and
+delete can ignore the `accepts_incomplete=true` query parameter if it is
+provided by the client.
 
 ### Asynchronous Operations
 
-Note: Asynchronous operations are currently supported only for provision, update, and deprovision.
+Note: Asynchronous operations are currently supported only for provision,
+update, and deprovision.
 
-For a broker to return an asynchronous response, the query parameter `accepts_incomplete=true` MUST be included the request. If the parameter is not included or is set to `false`, and the broker cannot fulfill the request synchronously (guaranteeing that the operation is complete on response), then the broker SHOULD reject the request with the status code `422 Unprocessable Entity` and the following body:
+For a service broker to return an asynchronous response, the query parameter
+`accepts_incomplete=true` MUST be included the request. If the parameter is
+not included or is set to `false`, and the service broker cannot fulfill the
+request synchronously (guaranteeing that the operation is complete on
+response), then the service broker SHOULD reject the request with the status
+code `422 Unprocessable Entity` and the following body:
 
 ```
 {
@@ -525,17 +574,25 @@ For a broker to return an asynchronous response, the query parameter `accepts_in
 }
 ```
 
-If the query parameter described above is present, and the broker executes the request asynchronously, the broker MUST return the asynchronous response `202 Accepted`. The response body SHOULD be the same as if the broker were serving the request synchronously.
+If the query parameter described above is present, and the service broker
+executes the request asynchronously, the service broker MUST return the
+asynchronous response `202 Accepted`. The response body SHOULD be the same as
+if the service broker were serving the request synchronously.
 
-An asynchronous response triggers the platform marketplace to poll the endpoint `GET /v2/service_instances/:instance_id/last_operation` until the broker indicates that the requested operation has succeeded or failed. Brokers MAY include a status message with each response for the `last_operation` endpoint that provides visibility to end users as to the progress of the operation.
+An asynchronous response triggers the platform marketplace to poll the
+endpoint `GET /v2/service_instances/:instance_id/last_operation` until the
+service broker indicates that the requested operation has succeeded or failed.
+Service brokers MAY include a status message with each response for the
+`last_operation` endpoint that provides visibility to end users as to the
+progress of the operation.
 
 #### Blocking Operations
 
-Brokers do not have to support concurrent requests that act on the same
-set of resources.  If a broker receives a request that it is not able to
-process due to other activity being done on that resource then the broker
-MUST reject the request with an HTTP `422 Unprocessable Entity`.
-The HTTP body of the response MUST include a `description` property
+Service brokers do not have to support concurrent requests that act on the
+same set of resources. If a service broker receives a request that it is not
+able to process due to other activity being done on that resource then the
+service broker MUST reject the request with an HTTP `422 Unprocessable
+Entity`. The HTTP body of the response MUST include a `description` property
 explaining the reason for the failure.
 
 Sample response:
@@ -547,9 +604,20 @@ Sample response:
 
 ## Polling Last Operation
 
-When a broker returns status code `202 Accepted` for [Provision](#provisioning), [Update](#updating-a-service-instance), or [Deprovision](#deprovisioning), the platform will begin polling the `/v2/service_instances/:instance_id/last_operation` endpoint to obtain the state of the last requested operation. The broker response MUST contain the field `state` and MAY contain the field `description`.
+When a service broker returns status code `202 Accepted` for
+[Provision](#provisioning), [Update](#updating-a-service-instance), or
+[Deprovision](#deprovisioning), the platform will begin polling the
+`/v2/service_instances/:instance_id/last_operation` endpoint to obtain the
+state of the last requested operation. The service broker response MUST
+contain the field `state` and MAY contain the field `description`.
 
-Valid values for `state` are `in progress`, `succeeded`, and `failed`. The platform will poll the `last_operation` endpoint as long as the broker returns `"state": "in progress"`. Returning `"state": "succeeded"` or `"state": "failed"` will cause the platform to cease polling. The value provided for `description` will be passed through to the platform API client and can be used to provide additional detail for users about the progress of the operation.
+Valid values for `state` are `in progress`, `succeeded`, and `failed`. The
+platform will poll the `last_operation` endpoint as long as the service broker
+returns `"state": "in progress"`. Returning `"state": "succeeded"` or
+`"state": "failed"` will cause the platform to cease polling. The value
+provided for `description` will be passed through to the platform API client
+and can be used to provide additional detail for users about the progress of
+the operation.
 
 ### Request
 
@@ -560,7 +628,7 @@ Valid values for `state` are `in progress`, `succeeded`, and `failed`. The platf
 
 #### Parameters
 
-The request provides these query string parameters as useful hints for brokers.
+The request provides these query string parameters as useful hints for service brokers.
 
 | Query-String Field | Type | Description |
 | --- | --- | --- |
@@ -568,7 +636,9 @@ The request provides these query string parameters as useful hints for brokers.
 | plan_id | string | ID of the plan from the catalog. If present, MUST be a non-empty string. |
 | operation | string | A broker-provided identifier for the operation. When a value for `operation` is included with asynchronous responses for [Provision](#provisioning), [Update](#updating-a-service-instance), and [Deprovision](#deprovisioning) requests, the platform MUST provide the same value using this query parameter as a percent-encoded string. If present, MUST be a non-empty string. |
 
-Note: Although the request query parameters `service_id` and `plan_id` are not mandatory, the platform SHOULD include them on all `last_operation` requests it makes to service brokers.
+Note: Although the request query parameters `service_id` and `plan_id` are not
+mandatory, the platform SHOULD include them on all `last_operation` requests
+it makes to service brokers.
 
 #### Headers
 
@@ -582,7 +652,7 @@ The following HTTP Headers are defined for this operation:
 
 #### cURL
 ```
-$ curl http://username:password@broker-url/v2/service_instances/:instance_id/last_operation -H "X-Broker-API-Version: 2.13"
+$ curl http://username:password@service-broker-url/v2/service_instances/:instance_id/last_operation -H "X-Broker-API-Version: 2.13"
 ```
 
 ### Response
@@ -593,11 +663,20 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id/las
 | 400 Bad Request | MUST be returned if the request is malformed or missing mandatory data. |
 | 410 Gone | Appropriate only for asynchronous delete operations. The platform MUST consider this response a success and remove the resource from its database. The expected response body is `{}`. Returning this while the platform is polling for create or update operations SHOULD be interpreted as an invalid response and the platform SHOULD continue polling. |
 
-Responses with any other status code SHOULD be interpreted as an error or invalid response. The platform SHOULD continue polling until the broker returns a valid response or the [maximum polling duration](#polling-interval-and-duration) is reached. Brokers MAY use the `description` field to expose user-facing error messages about the operation state; for more info see [Broker Errors](#broker-errors).
+Responses with any other status code SHOULD be interpreted as an error or
+invalid response. The platform SHOULD continue polling until the service
+broker returns a valid response or the [maximum polling
+duration](#polling-interval-and-duration) is reached. Service brokers MAY use
+the `description` field to expose user-facing error messages about the
+operation state; for more info see [Service Broker
+Errors](#service-broker-errors).
 
 #### Body
 
-All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
+All response bodies MUST be a valid JSON Object (`{}`). This is for future
+compatibility; it will be easier to add fields in the future if JSON is
+expected rather than to support the cases when a JSON body might or might not
+be returned.
 
 For success responses, the following fields are valid.
 
@@ -617,11 +696,19 @@ For success responses, the following fields are valid.
 
 ### Polling Interval and Duration
 
-The frequency and maximum duration of polling MAY vary by platform client. If a platform has a max polling duration and this limit is reached, the platform MUST cease polling and the operation state MUST be considered `failed`.
+The frequency and maximum duration of polling MAY vary by platform client. If
+a platform has a max polling duration and this limit is reached, the platform
+MUST cease polling and the operation state MUST be considered `failed`.
 
 ## Provisioning
 
-When the broker receives a provision request from the platform, it MUST take whatever action is necessary to create a new resource. What provisioning represents varies by service and plan, although there are several common use cases. For a MySQL service, provisioning could result in an empty dedicated database server running on its own VM or an empty schema on a shared database server. For non-data services, provisioning could just mean an account on an multi-tenant SaaS application.
+When the service broker receives a provision request from the platform, it
+MUST take whatever action is necessary to create a new resource. What
+provisioning represents varies by service and plan, although there are several
+common use cases. For a MySQL service, provisioning could result in an empty
+dedicated database server running on its own VM or an empty schema on a shared
+database server. For non-data services, provisioning could just mean an
+account on an multi-tenant SaaS application.
 
 ### Request
 
@@ -630,12 +717,12 @@ When the broker receives a provision request from the platform, it MUST take wha
 
 `:instance_id` MUST be a globally unique non-empty string.
 This ID will be used for future requests (bind and deprovision), so the
-broker will use it to correlate the resource it creates.
+service broker will use it to correlate the resource it creates.
 
 #### Parameters
 | Parameter name | Type | Description |
 | --- | --- | --- |
-| accepts_incomplete | boolean | A value of true indicates that the marketplace and its clients support asynchronous broker operations. If this parameter is not included in the request, and the broker can only provision a service instance of the requested plan asynchronously, the broker MUST reject the request with a `422 Unprocessable Entity` as described below. |
+| accepts_incomplete | boolean | A value of true indicates that the marketplace and its clients support asynchronous service broker operations. If this parameter is not included in the request, and the service broker can only provision a service instance of the requested plan asynchronously, the service broker MUST reject the request with a `422 Unprocessable Entity` as described below. |
 
 #### Headers
 
@@ -653,10 +740,10 @@ The following HTTP Headers are defined for this operation:
 | --- | --- | --- |
 | service_id* | string | The ID of the service (from the catalog). MUST be globally unique. MUST be a non-empty string. |
 | plan_id* | string | The ID of the plan (from the catalog) for which the service instance has been requested. MUST be unique within the service. MUST be a non-empty string. |
-| context | object | Platform specific contextual information under which the service instance is to be provisioned. Although most brokers will not use this field, it could be helpful in determining data placement or applying custom business rules. `context` will replace `organization_guid` and `space_guid` in future versions of the specification - in the interim both SHOULD be used to ensure interoperability with old and new implementations. |
-| organization_guid* | string | Deprecated in favor of `context`. The platform GUID for the organization under which the service instance is to be provisioned. Although most brokers will not use this field, it might be helpful for executing operations on a user's behalf. MUST be a non-empty string. |
-| space_guid* | string | Deprecated in favor of `context`. The identifier for the project space within the platform organization. Although most brokers will not use this field, it might be helpful for executing operations on a user's behalf. MUST be a non-empty string. |
-| parameters | JSON object | Configuration options for the service instance. Brokers SHOULD ensure that the client has provided valid configuration parameters and values for the operation. |
+| context | object | Platform specific contextual information under which the service instance is to be provisioned. Although most service brokers will not use this field, it could be helpful in determining data placement or applying custom business rules. `context` will replace `organization_guid` and `space_guid` in future versions of the specification - in the interim both SHOULD be used to ensure interoperability with old and new implementations. |
+| organization_guid* | string | Deprecated in favor of `context`. The platform GUID for the organization under which the service instance is to be provisioned. Although most service brokers will not use this field, it might be helpful for executing operations on a user's behalf. MUST be a non-empty string. |
+| space_guid* | string | Deprecated in favor of `context`. The identifier for the project space within the platform organization. Although most service brokers will not use this field, it might be helpful for executing operations on a user's behalf. MUST be a non-empty string. |
+| parameters | JSON object | Configuration options for the service instance. Service brokers SHOULD ensure that the client has provided valid configuration parameters and values for the operation. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -679,7 +766,7 @@ The following HTTP Headers are defined for this operation:
 
 #### cURL
 ```
-$ curl http://username:password@broker-url/v2/service_instances/:instance_id?accepts_incomplete=true -d '{
+$ curl http://username:password@service-broker-url/v2/service_instances/:instance_id?accepts_incomplete=true -d '{
   "service_id": "service-id-here",
   "plan_id": "plan-id-here",
   "context": {
@@ -703,20 +790,24 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id?acc
 | 201 Created | MUST be returned if the service instance was provisioned as a result of this request. The expected response body is below. |
 | 202 Accepted | MUST be returned if the service instance provisioning is in progress. This triggers the platform marketplace to poll the [Service Instance Last Operation Endpoint](#polling-last-operation) for operation status. Note that a re-sent `PUT` request MUST return a `202 Accepted`, not a `200 OK`, if the service instance is not yet fully provisioned. |
 | 400 Bad Request | MUST be returned if the request is malformed or missing mandatory data. |
-| 409 Conflict | MUST be returned if a service instance with the same id already exists but with different attributes. The expected response body is `{}`, though the description field MAY be used to return a user-facing error message, as described in [Broker Errors](#broker-errors). |
-| 422 Unprocessable Entity | MUST be returned if the broker only supports asynchronous provisioning for the requested plan and the request did not include `?accepts_incomplete=true`. The expected response body is: `{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }`, as described below. |
+| 409 Conflict | MUST be returned if a service instance with the same id already exists but with different attributes. The expected response body is `{}`, though the description field MAY be used to return a user-facing error message, as described in [Service Broker Errors](#service-broker-errors). |
+| 422 Unprocessable Entity | MUST be returned if the service broker only supports asynchronous provisioning for the requested plan and the request did not include `?accepts_incomplete=true`. The expected response body is: `{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }`, as described below. |
 
-Responses with any other status code will be interpreted as a failure. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
+Responses with any other status code will be interpreted as a failure. Service brokers can include a user-facing message in the `description` field; for details see [Service Broker Errors](#service-broker-errors).
 
 #### Body
 
-All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
+All response bodies MUST be a valid JSON Object (`{}`). This is for future
+compatibility; it will be easier to add fields in the future if JSON is
+expected rather than to support the cases when a JSON body might or might not
+be returned.
 
-For success responses, a broker MUST return the following fields. For error responses, see [Broker Errors](#broker-errors).
+For success responses, a service broker MUST return the following fields. For
+error responses, see [Service Broker Errors](#service-broker-errors).
 
 | Response field | Type | Description |
 | --- | --- | --- |
-| dashboard_url | string | The URL of a web-based management user interface for the service instance; we refer to this as a service dashboard. The URL MUST contain enough information for the dashboard to identify the resource being accessed (`9189kdfsk0vfnku` in the example below). Note: a broker that wishes to return `dashboard_url` for a service instance MUST return it with the initial response to the provision request, even if the service is provisioned asynchronously. If present, MUST be a non-empty string. |
+| dashboard_url | string | The URL of a web-based management user interface for the service instance; we refer to this as a service dashboard. The URL MUST contain enough information for the dashboard to identify the resource being accessed (`9189kdfsk0vfnku` in the example below). Note: a service broker that wishes to return `dashboard_url` for a service instance MUST return it with the initial response to the provision request, even if the service is provisioned asynchronously. If present, MUST be a non-empty string. |
 | operation | string | For asynchronous responses, service brokers MAY return an identifier representing the operation. The value of this field MUST be provided by the platform with requests to the [Last Operation](#polling-last-operation) endpoint in a percent-encoded query parameter. If present, MUST be a non-empty string. |
 
 \* Fields with an asterisk are REQUIRED.
@@ -730,11 +821,22 @@ For success responses, a broker MUST return the following fields. For error resp
 
 ## Updating a Service Instance
 
-By implementing this endpoint, service broker authors can enable users to modify two attributes of an existing service instance: the service plan and parameters. By changing the service plan, users can upgrade or downgrade their service instance to other plans. By modifying parameters, users can change configuration options that are specific to a service or plan.
+By implementing this endpoint, service broker authors can enable users to
+modify two attributes of an existing service instance: the service plan and
+parameters. By changing the service plan, users can upgrade or downgrade their
+service instance to other plans. By modifying parameters, users can change
+configuration options that are specific to a service or plan.
 
-To enable support for the update of the plan, a broker MUST declare support per service by including `plan_updateable: true` in its [catalog endpoint](#catalog-management).
+To enable support for the update of the plan, a service broker MUST declare
+support per service by including `plan_updateable: true` in its [catalog
+endpoint](#catalog-management).
 
-Not all permutations of plan changes are expected to be supported. For example, a service might support upgrading from plan "shared small" to "shared large" but not to plan "dedicated". It is up to the broker to validate whether a particular permutation of plan change is supported. If a particular plan change is not supported, the broker SHOULD return a meaningful error message in response.
+Not all permutations of plan changes are expected to be supported. For
+example, a service might support upgrading from plan "shared small" to "shared
+large" but not to plan "dedicated". It is up to the service broker to validate
+whether a particular permutation of plan change is supported. If a particular
+plan change is not supported, the service broker SHOULD return a meaningful
+error message in response.
 
 ### Request
 
@@ -747,7 +849,7 @@ It MUST be the ID a previously provisioned service instance.
 #### Parameters
 | Parameter name | Type | Description |
 | --- | --- | --- |
-| accepts_incomplete | boolean | A value of true indicates that the marketplace and its clients support asynchronous broker operations. If this parameter is not included in the request, and the broker can only provision a service instance of the requested plan asynchronously, the broker SHOULD reject the request with a `422 Unprocessable Entity` as described below. |
+| accepts_incomplete | boolean | A value of true indicates that the marketplace and its clients support asynchronous service broker operations. If this parameter is not included in the request, and the service broker can only provision a service instance of the requested plan asynchronously, the service broker SHOULD reject the request with a `422 Unprocessable Entity` as described below. |
 
 #### Headers
 
@@ -766,8 +868,8 @@ The following HTTP Headers are defined for this operation:
 | --- | --- | --- |
 | context | object | Contextual data under which the service instance is created. |
 | service_id* | string | The ID of the service (from the catalog). MUST be globally unique. MUST be a non-empty string. |
-| plan_id | string | The ID of the plan (from the catalog) for which the service instance has been requested. MUST be unique within the service. If present, MUST be a non-empty string. If this field is not present in the request message, then the broker MUST NOT change the plan of the instance as a result of this request. |
-| parameters | JSON object | Configuration options for the service instance. Brokers SHOULD ensure that the client has provided valid configuration parameters and values for the operation. If this field is not present in the request message, then the broker MUST NOT change the parameters of the instance as a result of this request. |
+| plan_id | string | The ID of the plan (from the catalog) for which the service instance has been requested. MUST be unique within the service. If present, MUST be a non-empty string. If this field is not present in the request message, then the service broker MUST NOT change the plan of the instance as a result of this request. |
+| parameters | JSON object | Configuration options for the service instance. Service brokers SHOULD ensure that the client has provided valid configuration parameters and values for the operation. If this field is not present in the request message, then the service broker MUST NOT change the parameters of the instance as a result of this request. |
 | previous_values | object | Information about the service instance prior to the update. |
 | previous_values.service_id | string | Deprecated; determined to be unnecessary as the value is immutable. ID of the service for the service instance. If present, MUST be a non-empty string. |
 | previous_values.plan_id | string | ID of the plan prior to the update. If present, MUST be a non-empty string. |
@@ -799,7 +901,7 @@ The following HTTP Headers are defined for this operation:
 
 #### cURL
 ```
-$ curl http://username:password@broker-url/v2/service_instances/:instance_id?accepts_incomplete=true -d '{
+$ curl http://username:password@service-broker-url/v2/service_instances/:instance_id?accepts_incomplete=true -d '{
   "context": {
     "platform": "cloudfoundry",
     "some_field": "some-contextual-data"
@@ -826,15 +928,20 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id?acc
 | 200 OK | MUST be returned if the request's changes have been applied. The expected response body is `{}`. |
 | 202 Accepted | MUST be returned if the service instance update is in progress. This triggers the platform marketplace to poll the [Last Operation](#polling-last-operation) for operation status. Note that a re-sent `PATCH` request MUST return a `202 Accepted`, not a `200 OK`, if the requested update has not yet completed. |
 | 400 Bad Request | MUST be returned if the request is malformed or missing mandatory data. |
-| 422 Unprocessable entity | MUST be returned if the requested change is not supported or if the request cannot currently be fulfilled due to the state of the service instance (e.g. service instance utilization is over the quota of the requested plan). Brokers SHOULD include a user-facing message in the body; for details see [Broker Errors](#broker-errors). Additionally, a `422 Unprocessable Entity` can also be returned if the broker only supports asynchronous update for the requested plan and the request did not include `?accepts_incomplete=true`; in this case the expected response body is: `{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }`. |
+| 422 Unprocessable entity | MUST be returned if the requested change is not supported or if the request cannot currently be fulfilled due to the state of the service instance (e.g. service instance utilization is over the quota of the requested plan). Service brokers SHOULD include a user-facing message in the body; for details see [Service Broker Errors](#service-broker-errors). Additionally, a `422 Unprocessable Entity` can also be returned if the service broker only supports asynchronous update for the requested plan and the request did not include `?accepts_incomplete=true`; in this case the expected response body is: `{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }`. |
 
-Responses with any other status code will be interpreted as a failure. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
+Responses with any other status code will be interpreted as a failure. Service brokers can include a user-facing message in the `description` field; for details see [Service Broker Errors](#service-broker-errors).
 
 #### Body
 
-All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
+All response bodies MUST be a valid JSON Object (`{}`). This is for future
+compatibility; it will be easier to add fields in the future if JSON is
+expected rather than to support the cases when a JSON body might or might not
+be returned.
 
-For success responses, a broker MUST return the following field. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
+For success responses, a service broker MUST return the following field.
+Others will be ignored. For error responses, see [Service Broker
+Errors](#service-broker-errors).
 
 | Response field | Type | Description |
 | --- | --- | --- |
@@ -851,51 +958,63 @@ For success responses, a broker MUST return the following field. Others will be 
 
 ## Binding
 
-If `bindable:true` is declared for a service or plan in the [Catalog](#catalog-management) endpoint, the platform MAY request generation of a service binding.
+If `bindable:true` is declared for a service or plan in the
+[Catalog](#catalog-management) endpoint, the platform MAY request generation
+of a service binding.
 
-Note: Not all services need to be bindable --- some deliver value just from being provisioned. Brokers that offer services that are bindable MUST declare them as such using `bindable: true` in the [Catalog](#catalog-management). Brokers that do not offer any bindable services do not need to implement the endpoint for bind requests.
+Note: Not all services need to be bindable --- some deliver value just from
+being provisioned. Service brokers that offer services that are bindable MUST
+declare them as such using `bindable: true` in the
+[Catalog](#catalog-management). Service brokers that do not offer any bindable
+services do not need to implement the endpoint for bind requests.
 
 ### Types of Binding
 
 #### Credentials
 
-Credentials are a set of information used by an application or a user to utilize the service instance. If the broker supports generation of credentials it MUST return `credentials` in the response for a request to create a service binding. Credentials SHOULD be unique whenever possible, so access can be revoked for each binding without affecting consumers of other bindings for the service instance.
+Credentials are a set of information used by an application or a user to
+utilize the service instance. If the service broker supports generation of
+credentials it MUST return `credentials` in the response for a request to
+create a service binding. Credentials SHOULD be unique whenever possible, so
+access can be revoked for each binding without affecting consumers of other
+bindings for the service instance.
 
 #### Log Drain
 
 There are a class of service offerings that provide aggregation, indexing, and
 analysis of log data. To utilize these services an application that generates
-logs needs information for the location to which it will stream logs. A
-create binding response from a service broker that provides one of these
-services MUST include a `syslog_drain_url`. The platform MUST use the
+logs needs information for the location to which it will stream logs. A create
+binding response from a service broker that provides one of these services
+MUST include a `syslog_drain_url`. The platform MUST use the
 `syslog_drain_url` value when sending logs to the service.
 
-Brokers MUST NOT include a `syslog_drain_url` in a create binding response
-if the associated [Catalog](#catalog-management) entry for the service
-did not include a `"requires":["syslog_drain"]` property.
+Service brokers MUST NOT include a `syslog_drain_url` in a create binding
+response if the associated [Catalog](#catalog-management) entry for the
+service did not include a `"requires":["syslog_drain"]` property.
 
 #### Route Services
 
 There are a class of service offerings that intermediate requests to
 applications, performing functions such as rate limiting or authorization.
 
-If a platform supports route services, it MUST send a routable address,
-or endpoint, for the application along with the request to create a service
-binding using `"bind_resource":{"route":"some-address.com"}`. A broker MAY
-support configuration specific to an address using parameters; exposing this
-feature to users would require a platform to support binding multiple
+If a platform supports route services, it MUST send a routable address, or
+endpoint, for the application along with the request to create a service
+binding using `"bind_resource":{"route":"some-address.com"}`. A service broker
+MAY support configuration specific to an address using parameters; exposing
+this feature to users would require a platform to support binding multiple
 routable addresses to the same service instance.
 
 If a service is deployed in a configuration to support this behavior, the
-broker MUST return a `route_service_url` in the response for a request to
-create a binding, so that the platform knows where to proxy the application
-request.  If the service is deployed such that the network configuration to
+service broker MUST return a `route_service_url` in the response for a request
+to create a binding, so that the platform knows where to proxy the application
+request. If the service is deployed such that the network configuration to
 proxy application requests through instances of the service is managed
-out-of-band, the broker MUST NOT return `route_service_url` in the response.
+out-of-band, the service broker MUST NOT return `route_service_url` in the
+response.
 
-Brokers MUST NOT include a `route_service_url` in a create binding response
-if the associated [Catalog](#catalog-management) entry for the service
-did not include a `"requires":["route_forwarding"]` property.
+Service brokers MUST NOT include a `route_service_url` in a create binding
+response if the associated [Catalog](#catalog-management) entry for the
+service did not include a `"requires":["route_forwarding"]` property.
 
 #### Volume Services
 
@@ -903,7 +1022,7 @@ There are a class of services that provide network storage to applications
 via volume mounts in the application container. A create binding response
 from one of these services MUST include `volume_mounts`.
 
-Brokers MUST NOT include `volume_mounts` in a create binding response
+Service brokers MUST NOT include `volume_mounts` in a create binding response
 if the associated [Catalog](#catalog-management) entry for the service
 did not include a `"requires":["volume_mount"]` property.
 
@@ -916,7 +1035,7 @@ did not include a `"requires":["volume_mount"]` property.
 It MUST be the ID of a previously provisioned service instance.
 
 `:binding_id` MUST be a globally unique non-empty string.
-This ID will be used for future unbind requests, so the broker will use
+This ID will be used for future unbind requests, so the service broker will use
 it to correlate the resource it creates.
 
 #### Headers
@@ -939,19 +1058,18 @@ The following HTTP Headers are defined for this operation:
 | plan_id* | string | ID of the plan from the catalog. MUST be a non-empty string. |
 | app_guid | string | Deprecated in favor of `bind_resource.app_guid`. GUID of an application associated with the binding to be created. If present, MUST be a non-empty string. |
 | bind_resource | JSON object | A JSON object that contains data for platform resources associated with the binding to be created. See [Bind Resource Object](#bind-resource-object) for more information. |
-| parameters | JSON object | Configuration options for the service binding. Brokers SHOULD ensure that the client has provided valid configuration parameters and values for the operation. |
+| parameters | JSON object | Configuration options for the service binding. Service brokers SHOULD ensure that the client has provided valid configuration parameters and values for the operation. |
 
 
 ##### Bind Resource Object
 
-The `bind_resource` object contains platform specific information
-related to the context in which the service will be used.
-In some cases the platform might not be able to provide this information
-at the time of the binding request, therefore the `bind_resource` and
-its fields are OPTIONAL.
+The `bind_resource` object contains platform specific information related to
+the context in which the service will be used. In some cases the platform
+might not be able to provide this information at the time of the binding
+request, therefore the `bind_resource` and its fields are OPTIONAL.
 
-Below are some common fields that MAY be used. Platforms MAY choose to
-add additional ones as needed.
+Below are some common fields that MAY be used. Platforms MAY choose to add
+additional ones as needed.
 
 | Request Field | Type | Description |
 | --- | --- | --- |
@@ -987,7 +1105,7 @@ binding requests.
 
 #### cURL
 ```
-$ curl http://username:password@broker-url/v2/service_instances/:instance_id/service_bindings/:binding_id -d '{
+$ curl http://username:password@service-broker-url/v2/service_instances/:instance_id/service_bindings/:binding_id -d '{
   "context": {
     "platform": "cloudfoundry",
     "some_field": "some-contextual-data"
@@ -1011,16 +1129,25 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id/ser
 | 200 OK | MUST be returned if the binding already exists and the requested parameters are identical to the existing binding. The expected response body is below. |
 | 201 Created | MUST be returned if the binding was created as a result of this request. The expected response body is below. |
 | 400 Bad Request | MUST be returned if the request is malformed or missing mandatory data. |
-| 409 Conflict | MUST be returned if a service binding with the same id, for the same service instance, already exists but with different parameters. The expected response body is `{}`, though the description field MAY be used to return a user-facing error message, as described in [Broker Errors](#broker-errors). |
-| 422 Unprocessable Entity | MUST be returned if the broker requires that `app_guid` be included in the request body. The expected response body is: `{ "error": "RequiresApp", "description": "This service supports generation of credentials through binding an application only." }`. |
+| 409 Conflict | MUST be returned if a service binding with the same id, for the same service instance, already exists but with different parameters. The expected response body is `{}`, though the description field MAY be used to return a user-facing error message, as described in [Service Broker Errors](#service-broker-errors). |
+| 422 Unprocessable Entity | MUST be returned if the service broker requires that `app_guid` be included in the request body. The expected response body is: `{ "error": "RequiresApp", "description": "This service supports generation of credentials through binding an application only." }`. |
 
-Responses with any other status code will be interpreted as a failure and an unbind request will be sent to the broker to prevent an orphan being created on the broker. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
+Responses with any other status code will be interpreted as a failure and an
+unbind request will be sent to the service broker to prevent an orphan being
+created on the service broker. Service brokers can include a user-facing
+message in the `description` field; for details see [Service Broker
+Errors](#service-broker-errors).
 
 #### Body
 
-All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
+All response bodies MUST be a valid JSON Object (`{}`). This is for future
+compatibility; it will be easier to add fields in the future if JSON is
+expected rather than to support the cases when a JSON body might or might not
+be returned.
 
-For success responses, the following fields are supported. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
+For success responses, the following fields are supported. Others will be
+ignored. For error responses, see [Service Broker
+Errors](#service-broker-errors).
 
 | Response Field | Type | Description |
 | --- | --- | --- |
@@ -1041,7 +1168,8 @@ For success responses, the following fields are supported. Others will be ignore
 
 ##### Device Object
 
-Currently only shared devices are supported; a distributed file system which can be mounted on all app instances simultaneously.
+Currently only shared devices are supported; a distributed file system which
+can be mounted on all app instances simultaneously.
 
 | Field | Type | Description |
 | --- | --- | --- |
@@ -1082,25 +1210,30 @@ Currently only shared devices are supported; a distributed file system which can
 
 ## Unbinding
 
-Note: Brokers that do not provide any bindable services or plans do not need to implement this endpoint.
+Note: Service brokers that do not provide any bindable services or plans do
+not need to implement this endpoint.
 
-When a broker receives an unbind request from the marketplace, it MUST delete any resources associated with the binding. In the case where credentials were generated, this might result in requests to the service instance failing to authenticate.
+When a service broker receives an unbind request from the marketplace, it MUST
+delete any resources associated with the binding. In the case where
+credentials were generated, this might result in requests to the service
+instance failing to authenticate.
 
 ### Request
 
 #### Route
+
 `DELETE /v2/service_instances/:instance_id/service_bindings/:binding_id`
 
-`:instance_id` MUST be a globally unique non-empty string.
-It MUST be the ID of a previously provisioned service instance.
+`:instance_id` MUST be a globally unique non-empty string. It MUST be the ID
+of a previously provisioned service instance.
 
-`:binding_id` MUST be a globally unique non-empty string.
-It MUST be the the ID of a previously provisioned binding for that service
-instance.
+`:binding_id` MUST be a globally unique non-empty string. It MUST be the the
+ID of a previously provisioned binding for that service instance.
 
 #### Parameters
 
-The request provides these query string parameters as useful hints for brokers.
+The request provides these query string parameters as useful hints for service
+brokers.
 
 | Query-String Field | Type | Description |
 | --- | --- | --- |
@@ -1121,8 +1254,9 @@ The following HTTP Headers are defined for this operation:
 \* Headers with an asterisk are REQUIRED.
 
 #### cURL
+
 ```
-$ curl 'http://username:password@broker-url/v2/service_instances/:instance_id/
+$ curl 'http://username:password@service-broker-url/v2/service_instances/:instance_id/
   service_bindings/:binding_id?service_id=service-id-here&plan_id=plan-id-here' -X DELETE -H "X-Broker-API-Version: 2.13"
 ```
 
@@ -1134,29 +1268,35 @@ $ curl 'http://username:password@broker-url/v2/service_instances/:instance_id/
 | 400 Bad Request | MUST be returned if the request is malformed or missing mandatory data. |
 | 410 Gone | MUST be returned if the binding does not exist. The expected response body is `{}`. |
 
-Responses with any other status code will be interpreted as a failure and the binding will remain in the marketplace database. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
+Responses with any other status code will be interpreted as a failure and the
+binding will remain in the marketplace database. Service brokers can include a
+user-facing message in the `description` field; for details see [Service
+Broker Errors](#service-broker-errors).
 
 #### Body
 
-All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
+All response bodies MUST be a valid JSON Object (`{}`). This is for future
+compatibility; it will be easier to add fields in the future if JSON is
+expected rather than to support the cases when a JSON body might or might not
+be returned.
 
 For a success response, the expected response body is `{}`.
 
 ## Deprovisioning
 
-When a broker receives a deprovision request from the marketplace, it MUST
-delete any resources it created during the provision.
-Usually this means that all resources are immediately reclaimed for future
-provisions.
+When a service broker receives a deprovision request from the marketplace, it
+MUST delete any resources it created during the provision. Usually this means
+that all resources are immediately reclaimed for future provisions.
 
-Platforms MUST delete all bindings for a service prior
-to attempting to deprovision the service. This specification does not
-specify what a broker is to do if it receives a deprovision request
-while there are still bindings associated with it.
+Platforms MUST delete all bindings for a service prior to attempting to
+deprovision the service. This specification does not specify what a service
+broker is to do if it receives a deprovision request while there are still
+bindings associated with it.
 
 ### Request
 
 #### Route
+
 `DELETE /v2/service_instances/:instance_id`
 
 `:instance_id` MUST be a globally unique non-empty string.
@@ -1164,13 +1304,15 @@ It MUST be the ID a previously provisioned service instance.
 
 #### Parameters
 
-The request provides these query string parameters as useful hints for brokers.
+The request provides these query string parameters as useful hints for service
+brokers.
+
 
 | Query-String Field | Type | Description |
 | --- | --- | --- |
 | service_id* | string | ID of the service from the catalog. MUST be a non-empty string. |
 | plan_id* | string | ID of the plan from the catalog. MUST be a non-empty string. |
-| accepts_incomplete | boolean | A value of true indicates that both the marketplace and the requesting client support asynchronous deprovisioning. If this parameter is not included in the request, and the broker can only deprovision a service instance of the requested plan asynchronously, the broker MUST reject the request with a `422 Unprocessable Entity` as described below. |
+| accepts_incomplete | boolean | A value of true indicates that both the marketplace and the requesting client support asynchronous deprovisioning. If this parameter is not included in the request, and the service broker can only deprovision a service instance of the requested plan asynchronously, the service broker MUST reject the request with a `422 Unprocessable Entity` as described below. |
 
 \* Query parameters with an asterisk are REQUIRED.
 
@@ -1187,7 +1329,7 @@ The following HTTP Headers are defined for this operation:
 
 #### cURL
 ```
-$ curl 'http://username:password@broker-url/v2/service_instances/:instance_id?accepts_incomplete=true
+$ curl 'http://username:password@service-broker-url/v2/service_instances/:instance_id?accepts_incomplete=true
   &service_id=service-id-here&plan_id=plan-id-here' -X DELETE -H "X-Broker-API-Version: 2.13"
 ```
 
@@ -1199,15 +1341,23 @@ $ curl 'http://username:password@broker-url/v2/service_instances/:instance_id?ac
 | 202 Accepted | MUST be returned if the service instance deletion is in progress. This triggers the marketplace to poll the [Service Instance Last Operation Endpoint](#polling-last-operation) for operation status. Note that a re-sent `DELETE` request MUST return a `202 Accepted`, not a `200 OK`, if the delete request has not completed yet. |
 | 400 Bad Request | MUST be returned if the request is malformed or missing mandatory data. |
 | 410 Gone | MUST be returned if the service instance does not exist. The expected response body is `{}`. |
-| 422 Unprocessable Entity | MUST be returned if the broker only supports asynchronous deprovisioning for the requested plan and the request did not include `?accepts_incomplete=true`. The expected response body is: `{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }`, as described below. |
+| 422 Unprocessable Entity | MUST be returned if the service broker only supports asynchronous deprovisioning for the requested plan and the request did not include `?accepts_incomplete=true`. The expected response body is: `{ "error": "AsyncRequired", "description": "This service plan requires client support for asynchronous service operations." }`, as described below. |
 
-Responses with any other status code will be interpreted as a failure and the service instance will remain in the marketplace database. Brokers can include a user-facing message in the `description` field; for details see [Broker Errors](#broker-errors).
+Responses with any other status code will be interpreted as a failure and the
+service instance will remain in the marketplace database. Service brokers can
+include a user-facing message in the `description` field; for details see
+[Service Broker Errors](#service-broker-errors).
 
 #### Body
 
-All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
+All response bodies MUST be a valid JSON Object (`{}`). This is for future
+compatibility; it will be easier to add fields in the future if JSON is
+expected rather than to support the cases when a JSON body might or might not
+be returned.
 
-For success responses, the following fields are supported. Others will be ignored. For error responses, see [Broker Errors](#broker-errors).
+For success responses, the following fields are supported. Others will be
+ignored. For error responses, see [Service Broker
+Errors](#service-broker-errors).
 
 | Response field | Type | Description |
 | --- | --- | --- |
@@ -1221,19 +1371,27 @@ For success responses, the following fields are supported. Others will be ignore
 }
 ```
 
-## Broker Errors
+## Service Broker Errors
 
 ### Response
 
-Broker failures beyond the scope of the well-defined HTTP response codes listed
-above (like `410 Gone` on [Deprovisioning](#deprovisioning)) MUST return an appropriate HTTP response code
-(chosen to accurately reflect the nature of the failure) and a body containing a valid JSON Object (not an array).
+Service broker failures beyond the scope of the well-defined HTTP response
+codes listed above (like `410 Gone` on [Deprovisioning](#deprovisioning)) MUST
+return an appropriate HTTP response code (chosen to accurately reflect the
+nature of the failure) and a body containing a valid JSON Object (not an
+array).
 
 #### Body
 
-All response bodies MUST be a valid JSON Object (`{}`). This is for future compatibility; it will be easier to add fields in the future if JSON is expected rather than to support the cases when a JSON body might or might not be returned.
+All response bodies MUST be a valid JSON Object (`{}`). This is for future
+compatibility; it will be easier to add fields in the future if JSON is
+expected rather than to support the cases when a JSON body might or might not
+be returned.
 
-For error responses, the following fields are valid. Others will be ignored. If an empty JSON object is returned in the body `{}`, a generic message containing the HTTP response code returned by the broker will be displayed to the requester.
+For error responses, the following fields are valid. Others will be ignored.
+If an empty JSON object is returned in the body `{}`, a generic message
+containing the HTTP response code returned by the service broker will be
+displayed to the requester.
 
 | Response Field | Type | Description |
 | --- | --- | --- |
@@ -1247,15 +1405,26 @@ For error responses, the following fields are valid. Others will be ignored. If 
 
 ## Orphans
 
-The platform marketplace is the source of truth for service instances and bindings. Service brokers are expected to have successfully provisioned all the service instances and bindings that the marketplace knows about, and none that it doesn't.
+The platform marketplace is the source of truth for service instances and
+bindings. Service brokers are expected to have successfully provisioned all
+the service instances and bindings that the marketplace knows about, and none
+that it doesn't.
 
-Orphans can result if the broker does not return a response before a request from the marketplace times out (typically 60 seconds). For example, if a broker does not return a response to a provision request before the request times out, the broker might eventually succeed in provisioning a service instance after the marketplace considers the request a failure. This results in an orphan service instance on the broker's side.
+Orphans can result if the service broker does not return a response before a
+request from the marketplace times out (typically 60 seconds). For example, if
+a service broker does not return a response to a provision request before the
+request times out, the service broker might eventually succeed in provisioning
+a service instance after the marketplace considers the request a failure. This
+results in an orphan service instance on the service broker's side.
 
-To mitigate orphan service instances and bindings, the marketplace SHOULD attempt to delete resources it cannot be sure were successfully created, and SHOULD keep trying to delete them until the broker responds with a success.
+To mitigate orphan service instances and bindings, the marketplace SHOULD
+attempt to delete resources it cannot be sure were successfully created, and
+SHOULD keep trying to delete them until the service broker responds with a
+success.
 
 Platforms SHOULD initiate orphan mitigation in the following scenarios:
 
-| Status code of broker response | Platform interpretation of response | Platform initiates orphan mitigation? |
+| Status code of service broker response | Platform interpretation of response | Platform initiates orphan mitigation? |
 | --- | --- | --- |
 | 200 | Success | No |
 | 200 with malformed response | Failure | No |
@@ -1263,8 +1432,11 @@ Platforms SHOULD initiate orphan mitigation in the following scenarios:
 | 201 with malformed response | Failure | Yes |
 | All other 2xx | Failure | Yes |
 | 408 | Timeout failure | Yes |
-| All other 4xx | Broker rejected request | No |
-| 5xx | Broker error | Yes |
+| All other 4xx | Service broker rejected request | No |
+| 5xx | Service broker error | Yes |
 | Timeout | Failure | Yes |
 
-If the platform marketplace encounters an internal error provisioning a service instance or binding (for example, saving to the database fails), then it MUST at least send a single delete or unbind request to the service broker to prevent creation of an orphan.
+If the platform marketplace encounters an internal error provisioning a
+service instance or binding (for example, saving to the database fails), then
+it MUST at least send a single delete or unbind request to the service broker
+to prevent creation of an orphan.

--- a/spec.md
+++ b/spec.md
@@ -171,7 +171,7 @@ URLs:
 - `binding_id`
 - `operation`
 
-While this specification places no restriction on the set of characters use
+While this specification places no restriction on the set of characters used
 within these strings, it is RECOMMENDED that these properties only contain
 characters from the "Unreserved Characters" as defined by
 [RFC3986](https://tools.ietf.org/html/rfc3986#section-2.3). In other words:

--- a/tools/verify-tables.sh
+++ b/tools/verify-tables.sh
@@ -94,9 +94,9 @@ function checkForPunc() {
       continue
     fi
 
-    # Anything less than 3 words we ignore
+    # Anything less than 4 words we ignore
     count=$(echo "$col" | wc -w)
-    if (( "$count" < 3 )); then
+    if (( "$count" < 4 )); then
       continue
     fi
 


### PR DESCRIPTION
I have updated the usage of 'broker' and 'brokers' to 'service broker' and 'service brokers' respectively. I do this only because this is suppose to be a technical spec and if there is a time where there is more than one kind of broker the language here is precise.

I also formatted the paragraphs to 80 columns where I change broker->service broker.

Please take a look! Thanks! Any feedback is welcome.