### PR TITLE
Add diagram of workflows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,6 +133,9 @@ creating a new PR with the title of the proposed release. For example,
   `X-Broker-API-Version` headers) updated. Do not update the header
   `Open Service Broker API (master - might contain changes that are not yet released)`
   (this will be done if and when the release proposal is approved).
+  * Update [diagram.md](diagram.md) to show the new version number in the
+  header and link to the correct version of the Google Drawing from the
+  [OSBAPI Google Drive Folder](https://drive.google.com/drive/u/0/folders/0B427Up4C9IE0VmM0ZlhHTG1Rc0E).
 3. Open a new Pull Request titled **Release Proposal: v$major.$minor** from the
   branch of the fork to the master branch of the repository.
 4. Announce the release proposal on the next weekly call and notify the mailing

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 [Read the profile](https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/profile.md)
 
+[View the workflows](diagram.md)
+
 [Release Notes for past versions](https://github.com/openservicebrokerapi/servicebroker/blob/v2.13/release-notes.md)
 
 ## Working Changes

--- a/diagram.md
+++ b/diagram.md
@@ -1,0 +1,5 @@
+# Open Service Broker API v2.13 Workflows
+
+![Workflows](https://docs.google.com/drawings/d/e/2PACX-1vQhhzTYSje1CBCP85pg4z7_tuAdEkt3gvLpRBCzCrGzdrPqqDWwWsh3kEuM3Zc6lKamgTisrOUp7tL7/pub?w=1008&amp;h=4680)
+
+PMC members can edit the drawing [here](https://docs.google.com/drawings/d/1LDGED4dm-ets5Z_xQLzadnR42hgjyNMJj8-CpXO5fnc/edit).


### PR DESCRIPTION
Following on from #361 and the discussion last night's call, here is a PR that adds a diagram of the platform to service broker workflows to the repository.

The [diagram](https://docs.google.com/drawings/d/1LDGED4dm-ets5Z_xQLzadnR42hgjyNMJj8-CpXO5fnc/edit) is a Google Drawing hosted in the [OSBAPI](https://drive.google.com/drive/u/0/folders/0B427Up4C9IE0VmM0ZlhHTG1Rc0E) Google Drive folder which all PMC members should be able to edit. The new `diagram.md` file automatically [renders the live version](https://github.com/mattmcneeney/servicebroker/blob/91104e5de1ff1e18f143e7f08789aab588540882/diagram.md) of the linked drawing. I'm hoping this is a sensible approach as it means nobody has to learn any new 'drawing languages'.

I also updated `CONTRIBUTING.md` to ensure the workflow diagram is updated on a spec release (which I presume is the most sensible time that we will do this).

Feedback is welcome!