### PR TITLE
Imply https is ok for the spec

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -29,7 +29,7 @@
 
 ## API Overview
 
-The Service Broker API defines an HTTP interface between Platforms and Service
+The Service Broker API defines an HTTP(S) interface between Platforms and Service
 Brokers.
 
 The Service Broker is the component of the service that implements the Service


### PR DESCRIPTION
It is the norm to say http(s) when http and https are valid. Fixes https://github.com/openservicebrokerapi/servicebroker/issues/379