### PR TITLE
Define all objects the same way.

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -899,11 +899,18 @@ The following HTTP Headers are defined for this operation:
 | service_id* | string | MUST be the ID of a service from the catalog for this Service Broker. |
 | plan_id | string | If present, MUST be the ID of a plan from the service that has been requested. If this field is not present in the request message, then the Service Broker MUST NOT change the plan of the instance as a result of this request. |
 | parameters | object | Configuration options for the Service Instance. Service Brokers SHOULD ensure that the client has provided valid configuration parameters and values for the operation. If this field is not present in the request message, then the Service Broker MUST NOT change the parameters of the instance as a result of this request. |
-| previous_values | object | Information about the Service Instance prior to the update. |
-| previous_values.service_id | string | Deprecated; determined to be unnecessary as the value is immutable. If present, it MUST be the ID of the service for the Service Instance. |
-| previous_values.plan_id | string | If present, it MUST be the ID of the plan prior to the update. |
-| previous_values.organization_id | string | Deprecated as it was redundant information. Organization for the Service Instance MUST be provided by Platforms in the top-level field `context`. If present, it MUST be the ID of the organization specified for the Service Instance. |
-| previous_values.space_id | string | Deprecated as it was redundant information. Space for the Service Instance MUST be provided by Platforms in the top-level field `context`. If present, it MUST be the ID of the space specified for the Service Instance. |
+| [previous_values](#previous-values-object)() | object | Information about the Service Instance prior to the update. |
+
+\* Fields with an asterisk are REQUIRED.
+
+##### Previous Values Object
+
+| Request Field | Type | Description |
+| --- | --- | --- |
+| service_id | string | Deprecated; determined to be unnecessary as the value is immutable. If present, it MUST be the ID of the service for the Service Instance. |
+| plan_id | string | If present, it MUST be the ID of the plan prior to the update. |
+| organization_id | string | Deprecated as it was redundant information. Organization for the Service Instance MUST be provided by Platforms in the top-level field `context`. If present, it MUST be the ID of the organization specified for the Service Instance. |
+| space_id | string | Deprecated as it was redundant information. Space for the Service Instance MUST be provided by Platforms in the top-level field `context`. If present, it MUST be the ID of the space specified for the Service Instance. |
 
 \* Fields with an asterisk are REQUIRED.
 

--- a/spec.md
+++ b/spec.md
@@ -899,7 +899,7 @@ The following HTTP Headers are defined for this operation:
 | service_id* | string | MUST be the ID of a service from the catalog for this Service Broker. |
 | plan_id | string | If present, MUST be the ID of a plan from the service that has been requested. If this field is not present in the request message, then the Service Broker MUST NOT change the plan of the instance as a result of this request. |
 | parameters | object | Configuration options for the Service Instance. Service Brokers SHOULD ensure that the client has provided valid configuration parameters and values for the operation. If this field is not present in the request message, then the Service Broker MUST NOT change the parameters of the instance as a result of this request. |
-| [previous_values](#previous-values-object)() | object | Information about the Service Instance prior to the update. |
+| [previous_values](#previous-values-object) | object | Information about the Service Instance prior to the update. |
 
 \* Fields with an asterisk are REQUIRED.
 


### PR DESCRIPTION
Update instance defines `previous_values`, and then defines the properties of `previous_values` in the same table. This does not follow the pattern in the spec. 

Making this consistent. 