### PR TITLE
add opaque Bearer Token to approved authentication methods

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -232,6 +232,12 @@ part of a Kubernetes API call:
   }
   ```
 
+## Authentication
+
+The [specification](spec.md) requires that brokers implement HTTP Basic authentication, but also allows for other mechanisms if the platform and the broker agree upon them outside of the specification. This section contains a list of supported mechanisms that platforms and brokers support. The list will be growing as time goes on.
+
+- The [Kubernetes Service Catalog](https://github.com/kubernetes-incubator/service-catalog) supports arbitrary HTTP Bearer tokens over TLS as an authentication mechanism
+
 ## Service Metadata
 
 While the [specification](spec.md) does not mandate the property names used

--- a/profile.md
+++ b/profile.md
@@ -18,7 +18,6 @@ or REQUIRED level requirements defined herein.
   - [Context Object Properties](#context-object-properties)
   - [Cloud Foundry](#cloud-foundry)
   - [Kubernetes](#kubernetes)
-- [Platform to Service Broker Authentication](#platform-to-service-broker-authentication)
 - [Service Metadata](#service-metadata)
   - [Cloud Foundry Service Metadata](#cloud-foundry-service-metadata)
 
@@ -232,12 +231,6 @@ part of a Kubernetes API call:
     "namespace": "development"
   }
   ```
-
-## Platform to Service Broker Authentication
-
-The [specification](spec.md) requires that brokers implement HTTP Basic authentication, but also allows for other mechanisms if the platform and the broker agree upon them outside of the specification. This section contains a list of supported mechanisms that platforms and brokers support. The list will be growing as time goes on.
-
-- The [Kubernetes Service Catalog](https://github.com/kubernetes-incubator/service-catalog) supports arbitrary HTTP Bearer tokens over TLS as an authentication mechanism
 
 ## Service Metadata
 

--- a/profile.md
+++ b/profile.md
@@ -18,6 +18,7 @@ or REQUIRED level requirements defined herein.
   - [Context Object Properties](#context-object-properties)
   - [Cloud Foundry](#cloud-foundry)
   - [Kubernetes](#kubernetes)
+- [Platform to Service Broker Authentication](#platform-to-service-broker-authentication)
 - [Service Metadata](#service-metadata)
   - [Cloud Foundry Service Metadata](#cloud-foundry-service-metadata)
 

--- a/profile.md
+++ b/profile.md
@@ -232,7 +232,7 @@ part of a Kubernetes API call:
   }
   ```
 
-## Authentication
+## Platform to Service Broker Authentication
 
 The [specification](spec.md) requires that brokers implement HTTP Basic authentication, but also allows for other mechanisms if the platform and the broker agree upon them outside of the specification. This section contains a list of supported mechanisms that platforms and brokers support. The list will be growing as time goes on.
 

--- a/spec.md
+++ b/spec.md
@@ -170,9 +170,12 @@ specification. Please see the
 for details on these mechanisms.
 
 If authentication is used, the Service Broker MUST authenticate the request
-using the predetermined authentication mechanism, securing communications
-via TLS, and MUST return a `401 Unauthorized` response if the authentication
-fails.
+using the predetermined authentication mechanism, and MUST return a `401 Unauthorized`
+response if the authentication fails. 
+
+Additionally, the Service Broker MUST secure communucations with TLS. The Platform
+and Service Broker SHOULD agree whether the Service Broker should use a root-signed
+certificate or a self-signed certificate.
 
 Note: Using an authentication mechanism that is agreed to via out of band
 communications could lead to interoperability issues with other Platforms.

--- a/spec.md
+++ b/spec.md
@@ -157,11 +157,14 @@ While the communication between a Platform and Service Broker MAY be unsecure,
 it is RECOMMENDED that all communications between a Platform and a Service
 Broker are secured via TLS and authenticated.
 
-Unless there is some out of band communication and agreement between a
-Platform and a Service Broker, the Platform MUST authenticate with the
-Service Broker using HTTP basic authentication (the `Authorization:` header)
-on every request. This specification does not specify how Platform and Service
-Brokers agree on other methods of authentication.
+Unless there is some out of band communication and agreement between a Platform
+and a Service Broker, the Platform MUST authenticate with the Service Broker
+using HTTP basic authentication (the `Authorization:` header) or a bearer token
+(the `Authorization: Bearer` header) on every request. If using bearer tokens,
+TLS MUST be used used.  This specification does not specify how Platform and
+Service Brokers agree on other methods of authentication nor does it specify how
+the bearer token is issued or the how token lifecycle including token timeout
+and token renewal is handled.
 
 If authentication is used, the Service Broker MUST authenticate the request
 using the predetermined authentication mechanism and MUST return a `401

--- a/spec.md
+++ b/spec.md
@@ -171,10 +171,10 @@ for details on these mechanisms.
 
 If authentication is used, the Service Broker MUST authenticate the request
 using the predetermined authentication mechanism, and MUST return a `401 Unauthorized`
-response if the authentication fails. 
+response if the authentication fails.
 
 Additionally, the Service Broker MUST secure communucations with TLS. The Platform
-and Service Broker SHOULD agree whether the Service Broker should use a root-signed
+and Service Broker SHOULD agree whether the Service Broker will use a root-signed
 certificate or a self-signed certificate.
 
 Note: Using an authentication mechanism that is agreed to via out of band

--- a/spec.md
+++ b/spec.md
@@ -173,7 +173,7 @@ If authentication is used, the Service Broker MUST authenticate the request
 using the predetermined authentication mechanism, and MUST return a `401 Unauthorized`
 response if the authentication fails.
 
-Additionally, the Service Broker MUST secure communucations with TLS. The Platform
+Additionally, the Service Broker MUST secure communications with TLS. The Platform
 and Service Broker SHOULD agree whether the Service Broker will use a root-signed
 certificate or a self-signed certificate.
 

--- a/spec.md
+++ b/spec.md
@@ -7,7 +7,7 @@
     - [Change Policy](#change-policy)
     - [Changes Since v2.12](#changes-since-v212)
   - [API Version Header](#api-version-header)
-  - [Authentication](#authentication)
+  - [Platform to Service Broker Authentication](#platform-to-service-broker-authentication)
   - [URL Properties](#url-properties)
   - [Originating Identity](#originating-identity)
   - [Service Broker Errors](#service-broker-errors)
@@ -151,7 +151,7 @@ Service Broker MAY reject the request with `412 Precondition Failed` and
 provide a message that informs the operator of the API version that is to be
 used instead.
 
-## Authentication
+## Platform to Service Broker Authentication
 
 While the communication between a Platform and Service Broker MAY be unsecure,
 it is RECOMMENDED that all communications between a Platform and a Service
@@ -163,16 +163,15 @@ Service Broker using HTTP basic authentication (the `Authorization:` header)
 on every request. This specification does not specify how Platform and Service
 Brokers agree on other methods of authentication.
 
-An alternative to carrying basic authentication on every request is to utilize a
-bearer token via the `Authorization: Bearer` header.  When a bearer token is
-used additional processes are often needed to deal with token expiration and
-renewal.  These are details not covered by this specification and need to be
-worked out by the Platform.  If bearer tokens are used communication with the
-Broker MUST be secured over TLS.
+Platforms and brokers may agree on an authentication mechanism other than
+basic authentication, but the specific agreements are not covered by this
+specification. Please see the platform.md documentation for a description
+of each mechanism and platform support.
 
 If authentication is used, the Service Broker MUST authenticate the request
-using the predetermined authentication mechanism and MUST return a `401
-Unauthorized` response if the authentication fails.
+using the predetermined authentication mechanism, securing communications
+via TLS, and MUST return a 401 Unauthorized response if the authentication
+fails.
 
 Note: Using an authentication mechanism that is agreed to via out of band
 communications could lead to interoperability issues with other Platforms.

--- a/spec.md
+++ b/spec.md
@@ -165,10 +165,10 @@ Brokers agree on other methods of authentication.
 
 An alternative to carrying basic authentication on every request is to utilize a
 bearer token via the `Authorization: Bearer` header.  When a bearer token is
-used additional processes are often required to deal with token expiration and
-renewal.  These are details not covered by this specification and must be worked
-out by the Platform.  If bearer tokens are used communication with the Broker
-MUST be secured over TLS.
+used additional processes are often needed to deal with token expiration and
+renewal.  These are details not covered by this specification and need to be
+worked out by the Platform.  If bearer tokens are used communication with the
+Broker MUST be secured over TLS.
 
 If authentication is used, the Service Broker MUST authenticate the request
 using the predetermined authentication mechanism and MUST return a `401

--- a/spec.md
+++ b/spec.md
@@ -165,8 +165,9 @@ Brokers agree on other methods of authentication.
 
 Platforms and Service Brokers MAY agree on an authentication mechanism other
 than basic authentication, but the specific agreements are not covered by this
-specification. Please see the [profile](profile.md) documentation for a
-description of each mechanism and platform support.
+specification. Please see the 
+[Platform Features authentication mechanisms wiki document](https://github.com/openservicebrokerapi/servicebroker/wiki/Platform-Features)
+for details on these mechanisms.
 
 If authentication is used, the Service Broker MUST authenticate the request
 using the predetermined authentication mechanism, securing communications

--- a/spec.md
+++ b/spec.md
@@ -157,14 +157,18 @@ While the communication between a Platform and Service Broker MAY be unsecure,
 it is RECOMMENDED that all communications between a Platform and a Service
 Broker are secured via TLS and authenticated.
 
-Unless there is some out of band communication and agreement between a Platform
-and a Service Broker, the Platform MUST authenticate with the Service Broker
-using HTTP basic authentication (the `Authorization:` header) or a bearer token
-(the `Authorization: Bearer` header) on every request. If using bearer tokens,
-TLS MUST be used used.  This specification does not specify how Platform and
-Service Brokers agree on other methods of authentication nor does it specify how
-the bearer token is issued or the how token lifecycle including token timeout
-and token renewal is handled.
+Unless there is some out of band communication and agreement between a
+Platform and a Service Broker, the Platform MUST authenticate with the
+Service Broker using HTTP basic authentication (the `Authorization:` header)
+on every request. This specification does not specify how Platform and Service
+Brokers agree on other methods of authentication.
+
+An alternative to carrying basic authentication on every request is to utilize a
+bearer token via the `Authorization: Bearer` header.  When a bearer token is
+used additional processes are often required to deal with token expiration and
+renewal.  These are details not covered by this specification and must be worked
+out by the Platform.  If bearer tokens are used communication with the Broker
+MUST be secured over TLS.
 
 If authentication is used, the Service Broker MUST authenticate the request
 using the predetermined authentication mechanism and MUST return a `401

--- a/spec.md
+++ b/spec.md
@@ -163,14 +163,14 @@ Service Broker using HTTP basic authentication (the `Authorization:` header)
 on every request. This specification does not specify how Platform and Service
 Brokers agree on other methods of authentication.
 
-Platforms and brokers may agree on an authentication mechanism other than
-basic authentication, but the specific agreements are not covered by this
-specification. Please see the platform.md documentation for a description
-of each mechanism and platform support.
+Platforms and Service Brokers MAY agree on an authentication mechanism other
+than basic authentication, but the specific agreements are not covered by this
+specification. Please see the [profile](profile.md) documentation for a
+description of each mechanism and platform support.
 
 If authentication is used, the Service Broker MUST authenticate the request
 using the predetermined authentication mechanism, securing communications
-via TLS, and MUST return a 401 Unauthorized response if the authentication
+via TLS, and MUST return a `401 Unauthorized` response if the authentication
 fails.
 
 Note: Using an authentication mechanism that is agreed to via out of band


### PR DESCRIPTION
fixes #381 

per https://tools.ietf.org/html/rfc6750 I explicitly called out that when using bearer tokens you must be using TLS.