### PR TITLE
deprecate orphan mitigation and add failure cleanup sections

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -715,9 +715,9 @@ For success responses, the following fields are valid.
 }
 ```
 
-If the successful response includes a `state` of `failed` then the Platform
-MUST send a deprovision request to the Service Broker to prevent an orphan
-being created on the Service Broker.
+If the successful response includes a `state` of `failed`, then the Platform
+MUST clean up the failed resource as per the [Provisioning Failure
+Cleanup](#failure-cleanup) section.
 
 ### Polling Interval and Duration
 
@@ -818,12 +818,10 @@ $ curl http://username:password@service-broker-url/v2/service_instances/:instanc
 | 409 Conflict | MUST be returned if a Service Instance with the same id already exists but with different attributes. The expected response body is `{}`, though the description field MAY be used to return a user-facing error message, as described in [Service Broker Errors](#service-broker-errors). |
 | 422 Unprocessable Entity | MUST be returned if the Service Broker only supports asynchronous provisioning for the requested plan and the request did not include `?accepts_incomplete=true`. The expected response body is: `{ "error": "AsyncRequired", "description": "This Service Plan requires client support for asynchronous service operations." }`, as described below (see [Service Broker Errors](#service-broker-errors). |
 
-Responses with any other status code will be interpreted as a failure and a
-deprovision request MUST be sent to the Service Broker to prevent an orphan
-being created on the Service Broker.
-
-Service Brokers can include a user-facing message in the `description` field;
-for details see [Service Broker Errors](#service-broker-errors).
+Request timeouts, responses with any other status code, or malformed response
+bodies will be interpreted as failures. Service Brokers can include a user-facing
+message in the `description` field; for details see [Service Broker
+Errors](#service-broker-errors).
 
 #### Body
 
@@ -848,6 +846,15 @@ error responses, see [Service Broker Errors](#service-broker-errors).
   "operation": "task_10"
 }
 ```
+
+### Failure Cleanup
+
+There could potentially be side effects on the Service Broker as a result of an
+unsuccessful provision attempt. If a provision request has been sent to a Service
+Broker, then the Platform MUST send a deprovision request at some point before
+cleaning up its internal representation of the Service Instance. If the
+deprovision attempt fails, the Platform SHOULD keep retrying until the Service
+Broker responds with a success or the Platform reaches its internal retry limit.
 
 ## Updating a Service Instance
 
@@ -1182,9 +1189,8 @@ $ curl http://username:password@service-broker-url/v2/service_instances/:instanc
 | 409 Conflict | MUST be returned if a Service Binding with the same id, for the same Service Instance, already exists but with different parameters. The expected response body is `{}`, though the description field MAY be used to return a user-facing error message, as described in [Service Broker Errors](#service-broker-errors). Additionally, if the Service Broker rejects the request due to a concurrent request to create a binding for the same Service Instance, then this error MUST be returned (see [Blocking Operations](#blocking-operations)). |
 | 422 Unprocessable Entity | MUST be returned if the Service Broker requires that `app_guid` be included in the request body. The expected response body is: `{ "error": "RequiresApp", "description": "This service supports generation of credentials through binding an application only." }` (see [Service Broker Errors](#service-broker-errors). |
 
-Responses with any other status code will be interpreted as a failure and an
-unbind request MUST be sent to the Service Broker to prevent an orphan being
-created on the Service Broker. Service Brokers can include a user-facing
+Request timeouts, responses with any other status code, or malformed response
+bodies will be interpreted as failures. Service Brokers can include a user-facing
 message in the `description` field; for details see [Service Broker
 Errors](#service-broker-errors).
 
@@ -1257,6 +1263,15 @@ can be mounted on all app instances simultaneously.
   }]
 }
 ```
+
+### Failure Cleanup
+
+There could potentially be side effects on the Service Broker as a result of an
+unsuccessful bind attempt. If a bind request has been sent to a Service Broker,
+then the Platform MUST send an unbind request at some point before cleaning up
+its internal representation of the Service Instance. If the unbind attempt fails,
+the Platform SHOULD keep retrying until the Service Broker responds with a
+success or the Platform reaches its internal retry limit.
 
 ## Unbinding
 
@@ -1457,39 +1472,3 @@ that SHOULD be used in the error response message. Each error definition will
 also include a `description` property that is RECOMMENDED to be used. However,
 the Service Broker MAY use a different `description` string if appropriate, for
 example, to specify a description in a different language.
-
-## Orphans
-
-The Platform is the source of truth for Service Instances and bindings. Service
-Brokers are expected to have successfully provisioned all the Service Instances
-and bindings that the Platform knows about, and none that it doesn't.
-
-Orphans can result if the Service Broker does not return a response before a
-request from the Platform times out (typically 60 seconds). For example, if a
-Service Broker does not return a response to a provision request before the
-request times out, the Service Broker might eventually succeed in provisioning
-a Service Instance after the Platform considers the request a failure. This
-results in an orphan Service Instance on the Service Broker's side.
-
-To mitigate orphan Service Instances and bindings, the Platform SHOULD attempt
-to delete resources it cannot be sure were successfully created, and SHOULD keep
-trying to delete them until the Service Broker responds with a success.
-
-Platforms SHOULD initiate orphan mitigation in the following scenarios:
-
-| Status code of Service Broker response | Platform interpretation of response | Platform initiates orphan mitigation? |
-| --- | --- | --- |
-| 200 | Success | No |
-| 200 with malformed response | Failure | No |
-| 201 | Success | No |
-| 201 with malformed response | Failure | Yes |
-| All other 2xx | Failure | Yes |
-| 408 | Timeout failure | Yes |
-| All other 4xx | Request rejected | No |
-| 5xx | Service Broker error | Yes |
-| Timeout | Failure | Yes |
-
-If the Platform encounters an internal error provisioning a Service Instance or
-binding (for example, saving to the database fails), then it MUST at least send
-a single delete or unbind request to the Service Broker to prevent creation of
-an orphan.

--- a/spec.md
+++ b/spec.md
@@ -1485,7 +1485,7 @@ Platforms SHOULD initiate orphan mitigation in the following scenarios:
 | 201 with malformed response | Failure | Yes |
 | All other 2xx | Failure | Yes |
 | 408 | Timeout failure | Yes |
-| All other 4xx | Service Broker rejected request | No |
+| All other 4xx | Request rejected | No |
 | 5xx | Service Broker error | Yes |
 | Timeout | Failure | Yes |
 

--- a/tools/verify-all.sh
+++ b/tools/verify-all.sh
@@ -34,7 +34,7 @@ echo Verifying hrefs
 "${REPODIR}/tools/verify-links.sh" -v "${REPODIR}" || rc=1
 
 echo Verify tables
-"${REPODIR}/tools/verify-tables.sh" "${REPODIR}"/spec.md "${REPODIR}"/profile.md || rc=1
+"${REPODIR}/tools/verify-tables.sh" -v "${REPODIR}"/spec.md "${REPODIR}"/profile.md || rc=1
 
 echo Verify terminology and RFC keywords
 "${REPODIR}/tools/verify-phrases.sh" -v "${REPODIR}"/spec.md "${REPODIR}"/profile.md || rc=1

--- a/tools/verify-links.sh
+++ b/tools/verify-links.sh
@@ -272,8 +272,5 @@ for file in ${mdFiles}; do
 
   done
 done
-rc=0
-if [ -a ${tmp}3 ]; then
-  rc=1
-fi
-exit $rc
+
+if [ -s ${tmp}3 ]; then exit 1 ; fi

--- a/tools/verify-phrases.sh
+++ b/tools/verify-phrases.sh
@@ -52,6 +52,13 @@ verbose=""
 debug=""
 stop=""
 
+# Error file processing
+err=tmpCC-$RANDOM
+trap clean EXIT
+function clean {
+  rm -f ${err}*
+}
+
 while [[ "$#" != "0" && "$1" == "-"* ]]; do
   opts="${1:1}"
   while [[ "$opts" != "" ]]; do
@@ -102,9 +109,6 @@ function checkFile {
   lines=( "" )
   words=( "" )
 
-  # Error file
-  err=tmpCC-$RANDOM
-
   # Prepend each line of the file with its line number
   cat -n $1 | while read num line ; do
     # Put each word on its own line with its line number before it.
@@ -152,7 +156,7 @@ function checkFile {
       if [[ "${words[@]^^} " == "${phrase^^} "* && \
             "${words[@]} " != "${phrase} "* ]]; then
       ll=${words[*]}
-      echo line ${lines[0]}: \'${ll:0:${#phrase}}\' should be \'${phrase}\' | tee -a $err
+      echo line ${lines[0]}: \'${ll:0:${#phrase}}\' should be \'${phrase}\'
     fi
     done
 
@@ -161,18 +165,11 @@ function checkFile {
     for phrase in "${bannedPhrases[@]}"; do
       if [[ "${words[@]^^} " == "${phrase^^} "* ]]; then
       ll=${words[*]}
-      echo line ${lines[0]}: \'${ll:0:${#phrase}}\' is banned | tee -a $err
+      echo line ${lines[0]}: \'${ll:0:${#phrase}}\' is banned
     fi
     done
 
   done
-  
-  # Check err file to see if something went wrong
-  if [ -s $err ]; then
-    rm -f $err
-    return 1
-  fi
-  rm -f $err
 }
 
 for file in ${Files}; do
@@ -181,5 +178,7 @@ for file in ${Files}; do
 
   [[ -n "$verbose" ]] && echo "> $file"
 
-  checkFile $file
+  checkFile $file | tee -a $err
 done
+
+if [ -s ${err} ]; then exit 1 ; fi


### PR DESCRIPTION
This PR deprecates orphan mitigation and adds a failure cleanup section to the Provisioning and Binding sections.

Closes #397, closes #370, closes #369