### PR TITLE
Add space_guid to Cloud Foundry bind_resource extension in profile.md

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -13,11 +13,17 @@ or REQUIRED level requirements defined herein.
 ## Table of Contents
 
 - [Notations and Terminology](#notations-and-terminology)
+  - [Notational Conventions](#notational-conventions)
+  - [Terminology](#terminology)
 - [Originating Identity Header](#originating-identity-header)
+  - [Cloud Foundry Originating Identity Header](#cloud-foundry-originating-identity-header)
+  - [Kubernetes Originating Identity Header](#kubernetes-originating-identity-header)
 - [Context Object](#context-object)
   - [Context Object Properties](#context-object-properties)
-  - [Cloud Foundry](#cloud-foundry)
-  - [Kubernetes](#kubernetes)
+  - [Cloud Foundry Context Object](#cloud-foundry-context-object)
+  - [Kubernetes Context Object](#kubernetes-context-object)
+- [Bind Resource Object](#bind-resource-object)
+  - [Cloud Foundry Bind Resource Object](#cloud-foundry-bind-resource-object)
 - [Service Metadata](#service-metadata)
   - [Cloud Foundry Service Metadata](#cloud-foundry-service-metadata)
 
@@ -50,7 +56,7 @@ Note that when both the originating identity HTTP Header and the Context
 object appear in the same message the `platform` value MUST be the same
 for both.
 
-### Cloud Foundry
+### Cloud Foundry Originating Identity Header
 
 *`platform` Value*: `cloudfoundry`
 
@@ -73,7 +79,7 @@ would appear in the HTTP Header as:
 X-Broker-API-Originating-Identity: cloudfoundry eyANCiAgInVzZXJfaWQiOiAiNjgzZWE3NDgtMzA5Mi00ZmY0LWI2NTYtMzljYWNjNGQ1MzYwIiwNCiAgInVzZXJfbmFtZSI6ICJqb2VAZXhhbXBsZS5jb20iDQp9
 ```
 
-### Kubernetes
+### Kubernetes Originating Identity Header
 
 *`platform` Value*: `kubernetes`
 
@@ -111,8 +117,6 @@ In the [Open Service Broker API specification](spec.md) there are certain
 message flows that include a `context` property. This property is defined
 as an opaque JSON object that is meant to contain contextual information
 about the environment in which the Platform or Application is executing.
-For example, it might include the organizational information (eg. a
-Cloud Foundry `organization` GUID) in which the Application is owned.
 
 While the `context` property is defined as an opaque JSON object, in practice,
 it is often useful and necessary for there to be an agreed upon set of
@@ -143,17 +147,16 @@ Note that when both the originating identity HTTP Header and the Context
 object appear in the same message the `platform` value MUST be the same
 for both.
 
-#### Cloud Foundry
+### Cloud Foundry Context Object
 
 *`platform` Property Value*: `cloudfoundry`
 
 The following properties are defined for usage within a Cloud Foundry
 deployment:
 
-- `organization_guid`<br>
-  The organization GUID as defined by the Cloud Foundry
-  specification/project. This property MUST be a non-empty string serialized
-  as follows:
+- `organization_guid`  
+  The GUID of the organization that a Service Instance is associated with.
+  This property MUST be a non-empty string serialized as follows:
   ```
   "organization_guid": "organization-guid-here"
   ```
@@ -162,10 +165,9 @@ deployment:
   "organization_guid": "1113aa0-124e-4af2-1526-6bfacf61b111"
   ```
 
-- `space_guid`<br>
-  The space GUID as defined by the Cloud Foundry
-  specification/project. This property MUST be a non-empty string serialized
-  as follows:
+- `space_guid`  
+  The GUID of the space that a Service Instance is associated with.
+  This property MUST be a non-empty string serialized as follows:
   ```
   "space_guid": "space-guid-here"
   ```
@@ -174,18 +176,17 @@ deployment:
   "space_guid": "aaaa1234-da91-4f12-8ffa-b51d0336aaaa"
   ```
 
-The following table specifies which properties MUST appear in each API:
+The following table specifies the REQUIRED properties for requests from a
+Platform to a Service Broker:
 
 | Request API | Properties |
-| --- | --- |
-| `PUT /v2/service_instances/:instance_id` | `organization_guid`<br>`space_guid` |
-| `PATCH /v2/service_instances/:instance_id` | `organization_guid`<br>`space_guid` |
-| `PUT /v2/service_instances/:instance_id/service_bindings/:binding_id` | `organization_guid`<br>`space_guid` |
+| --- | --- | --- |
+| `PUT /v2/service_instances/:instance_id` | `organization_guid`, `space_guid` |
+| `PATCH /v2/service_instances/:instance_id` | `organization_guid`, `space_guid` |
+| `PUT /v2/service_instances/:instance_id/service_bindings/:binding_id` | `organization_guid`, `space_guid` |
 
-Example:
-
-The following example shows a `context` property that might appear as
-part of a Cloud Foundry API call:
+The following example shows a `context` object that might appear as part of a
+Cloud Foundry API call:
   ```
   "context": {
     "platform": "cloudfoundry",
@@ -194,7 +195,7 @@ part of a Cloud Foundry API call:
   }
   ```
 
-#### Kubernetes
+### Kubernetes Context Object
 
 *`platform` Property Value*: `kubernetes`
 
@@ -232,6 +233,38 @@ part of a Kubernetes API call:
   }
   ```
 
+## Bind Resource Object
+
+In the [Open Service Broker API specification](spec.md), requests to
+[create a Service Binding](spec.md#binding) can contain a `bind_resource`
+object in which Platforms MAY choose to add additional fields.
+
+### Cloud Foundry Bind Resource Object
+
+The following properties are defined for usage within a Cloud Foundry
+deployment:
+
+- `space_guid`  
+  This OPTIONAL property is the GUID of a space that a Service Binding is
+  associated with. If present, this property MUST be a non-empty string
+  serialized as follows:
+  ```
+  "space_guid": "space-guid-here"
+  ```
+  For example:
+  ```
+  "space_guid": "15823972-c216-4ba5-9f3f-e75b0b891297"
+  ```
+
+The following example shows a `bind_resource` object that might appear as part
+of a Cloud Foundry API call:
+  ```
+  "bind_resource": {
+    "app_guid": "5e76c9bf-d5e3-46bf-9877-6d8dddfc8a45",
+    "space_guid": "15823972-c216-4ba5-9f3f-e75b0b891297"
+  }
+  ```
+
 ## Service Metadata
 
 While the [specification](spec.md) does not mandate the property names used
@@ -239,7 +272,7 @@ in the `metadata` objects, it is RECOMMENDED that the following names
 be used when possible in an attempt to provide some degree of interoperability
 and consistency.
 
-### Service Metadata Fields
+#### Service Metadata Fields
 
 | Service Broker API Field | Type | Description |
 | --- | --- | --- |
@@ -250,7 +283,7 @@ and consistency.
 | metadata.documentationUrl | string | Link to documentation page for the service. |
 | metadata.supportUrl | string | Link to support page for the service. |
 
-### Plan Metadata Fields
+#### Plan Metadata Fields
 | Service Broker API Field | Type | Description |
 | --- | --- | --- |
 | metadata.bullets | array-of-strings | Features of this plan, to be displayed in a bulleted-list. |
@@ -280,7 +313,7 @@ For example:
 ]
 ```
 
-### Example Service Broker Response Body
+#### Example Service Broker Response Body
 
 The example below contains a catalog of one service, having one Service Plan.
 Of course, a Service Broker can offering a catalog of many services, each having

--- a/spec.md
+++ b/spec.md
@@ -1112,7 +1112,8 @@ might not be able to provide this information at the time of the binding
 request, therefore the `bind_resource` and its fields are OPTIONAL.
 
 Below are some common fields that MAY be used. Platforms MAY choose to add
-additional ones as needed.
+additional ones as needed (see
+[Bind Resource Object](profile.md#bind-resource-object) conventions).
 
 | Request Field | Type | Description |
 | --- | --- | --- |


### PR DESCRIPTION
Cloud Foundry sends an additional field in the `context` object when creating a service binding called `bind_resource.space_guid`, which indicates the Cloud Foundry space that the binding is associated with. This is not to be confused with the `space_guid` currently found in the `context` object, which indicates the space in which the service instance was/is going to be created.