### PR TITLE
Openapi schema fixes

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -507,7 +507,7 @@ components:
           $ref: '#/components/schemas/JSONSchema'
 
     JSONSchema:
-      type: object
+      $ref: 'http://json-schema.org/draft-04/schema'
 
     ServiceInstanceProvisionRequest:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -476,17 +476,17 @@ components:
         bindable:
           type: boolean
         schemas:
-          $ref: '#/components/schemas/SchemasObject'
+          $ref: '#/components/schemas/Schemas'
 
-    SchemasObject:
+    Schemas:
       type: object
       properties:
         service_instance:
-          $ref: '#/components/schemas/ServiceInstanceSchemaObject'
+          $ref: '#/components/schemas/ServiceInstanceSchema'
         service_binding:
-          $ref: '#/components/schemas/ServiceBindingSchemaObject'
+          $ref: '#/components/schemas/ServiceBindingSchema'
 
-    ServiceInstanceSchemaObject:
+    ServiceInstanceSchema:
       type: object
       properties:
         create:
@@ -494,7 +494,7 @@ components:
         update:
           $ref: '#/components/schemas/SchemaParameters'
 
-    ServiceBindingSchemaObject:
+    ServiceBindingSchema:
       type: object
       properties:
         create:
@@ -504,9 +504,9 @@ components:
       type: object
       properties:
         parameters:
-          $ref: '#/components/schemas/JSONSchemaObject'
+          $ref: '#/components/schemas/JSONSchema'
 
-    JSONSchemaObject:
+    JSONSchema:
       type: object
 
     ServiceInstanceProvisionRequest:


### PR DESCRIPTION
This fixes two things:
- removes "Object" suffix from some type names
- points the JSONSchema type definition to http://json-schema.org/draft-04/schema instead of it it being an arbitrary object (`type: object`)

I removed the "Object" suffix because it is unnecessary and makes the naming of these types inconsistent with other type definitions in the schema. For example, in the spec document, we call it "Plan Object", but in the OpenAPI schema, we simply call it `Plan`.

The following type definitions contained the "Object" suffix:
- SchemasObject
- ServiceInstanceSchemaObject
- ServiceBindingSchemaObject
- JSONSchemaObject