### PR TITLE
Remove language about cluster ID

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -228,43 +228,6 @@ The following properties are defined for usage within a Kubernetes deployment:
   "namespace": "testing"
   ```
 
-
-- `clusterid`
-
-  Version: 2.14
-
-  The unique identifier for the Kubernetes cluster from which the request
-  was sent. This property MUST be a non-empty string serialized as follows:
-
-  ```
-  "clusterid": "id-goes-here"
-  ```
-  For example:
-  ```
-  "clusterid": "644e1dd7-2a7f-18fb-b8ed-ed78c3f92c2b"
-  ```
-
-The following table specifies which properties will appear in each API.
-All properties specified are REQUIRED unless otherwise noted.
-
-| Request API | Properties |
-| --- | --- |
-| `PUT /v2/service_instances/:instance_id` | `namespace`, `clusterid` |
-| `PATCH /v2/service_instances/:instance_id` | `namespace`, `clusterid` |
-| `PUT /v2/service_instances/:instance_id/service_bindings/:binding_id` | `namespace`, `clusterid` |
-
-Example:
-
-The following example shows a `context` property that might appear as
-part of a Kubernetes API call:
-  ```
-  "context": {
-    "platform": "kubernetes",
-    "namespace": "development",
-    "clusterid": "8263feba-9b8a-23ae-99ed-abcd1234feda"
-  }
-  ```
-
 ## Bind Resource Object
 
 In the [Open Service Broker API specification](spec.md), requests to


### PR DESCRIPTION
Removes cluster ID language temporarily until we can discuss implementation in k8s further.

I have significant concerns about our ability to implement the feature as described here, and given the other discussions ongoing about the relationship of the spec to implementation concerns in the platform, I think it would be most prudent to remove this language until we can settle on a spec change and implementation in k8s that everyone can agree to.

I would like us to merge this, and explore an optional addition of the same field with weaker guarantees. I would also like to ensure that we have an optional implementation of this feature merged in the kubernetes catalog that users can try out and give us feedback, per our normal process in this spec, before we commit a permanent change.