### PR TITLE
Adding Deprecation support for Services and Plans

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -504,6 +504,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/Plan'
+        deprecation:
+          $ref: '#/components/schemas/Deprecation'
 
     DashboardClient:
       type: object
@@ -537,6 +539,28 @@ components:
           type: boolean
         schemas:
           $ref: '#/components/schemas/Schemas'
+        deprecation:
+          $ref: '#/components/schemas/Deprecation'
+
+    Deprecation:
+      type: object
+      properties:
+        description:
+          type: string
+        alternatives:
+          type: array
+          items:
+            $ref: '#/components/schemas/CatalogObject'
+
+    CatalogObject:
+      type: object
+      properties:
+        description:
+          type: string
+        service_id:
+          type: string
+        plan_id:
+          type: string
 
     Schemas:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -544,6 +544,8 @@ components:
 
     Deprecation:
       type: object
+      required:
+        - description
       properties:
         description:
           type: string

--- a/spec.md
+++ b/spec.md
@@ -616,7 +616,7 @@ schema being used.
 | description | string | A short description of the deprecation. |
 | since | date string | ISO 8601 formatted date when the Service Broker deprecated the service or plan. |
 | eol | date string | ISO 8601 formatted date when the Service Broker expects to remove the service or plan from the catalog. |
-| alternatives |  array of [CatalogObjectId](#catalog-object-id-object) objects  | An array of services or plans that the Service Broker considers to be good alternatives. |
+| alternatives | array of [CatalogObjectId](#catalog-object-id-object) objects | An array of services or plans that the Service Broker considers to be good alternatives. |
 
 \* Fields with an asterisk are REQUIRED.
 

--- a/spec.md
+++ b/spec.md
@@ -614,8 +614,8 @@ schema being used.
 | Response Field | Type | Description |
 | --- | --- | --- |
 | description | string | A short description of the deprecation. |
-| since | date string | Date and time when the Service Broker deprecated the service or plan. If specified, it is expected to be an ISO 8601 formatted date and time, with time zone. |
-| eol | date string | Date and time when the Service Broker expects to end-of-life (remove) the service or plan from the catalog. If specified, it is expected to be an ISO 8601 formatted date and time, with time zone. |
+| since | date string | Date and time when the Service Broker deprecated the service or plan. If specified, this field MUST be an ISO 8601 formatted date and time, with time zone. |
+| eol | date string | Date and time when the Service Broker expects to end-of-life (remove) the service or plan from the catalog. If specified, this field MUST be an ISO 8601 formatted date and time, with time zone. |
 | alternatives | array of [CatalogObjectId](#catalog-object-id-object) objects | An array of services or plans that the Service Broker considers to be good alternatives. |
 
 \* Fields with an asterisk are REQUIRED.

--- a/spec.md
+++ b/spec.md
@@ -594,7 +594,16 @@ schema being used.
       "id": "009aba-XXXX-XXXX-XXXX-dace631cd648",
       "description": "This is deprecated.",
       "free": false,
-      "deprecation": {}
+      "deprecation": {
+        "description": "Don't use this anymore.",
+        "since": "2018-04-20",
+        "eol": "2020-02-28",
+        "alternatives": [{
+            "description": "Use this plan instead.",
+            "plan_id": "0f4008b5-XXXX-XXXX-XXXX-dace631cd648"
+          }
+        ]
+      }
     }]
   }]
 }
@@ -607,9 +616,17 @@ schema being used.
 | description | string | A short description of the deprecation. |
 | since | date string | ISO 8601 formatted date when the Service Broker deprecated the service or plan. |
 | eol | date string | ISO 8601 formatted date when the Service Broker expects to remove the service or plan from the catalog. |
-| alternatives | array of strings | An array of alternatives services or plans that should be considered from the broker. This is a list of names. If the deprecated object is a service, these are service names. If the deprecated object is a plan, these are plan names within the same service. |
+| alternatives |  array of [CatalogObjectId](#catalog-object-id-object) objects  | An array of services or plans that the Service Broker considers to be good alternatives. |
 
 \* Fields with an asterisk are REQUIRED.
+
+##### Catalog Object Id Object 
+
+| Response Field | Type | Description |
+| --- | --- | --- |
+| description | string | A short description to provide contextual information about this catalog object reference. |
+| service_id | string | If present, it MUST be the ID of a service. |
+| plan_id | string | If present, it MUST be the ID of a plan. |
 
 ### Adding a Service Broker to the Platform
 

--- a/spec.md
+++ b/spec.md
@@ -648,8 +648,8 @@ Service Brokers MUST allow existing Service Instances to be updated and
 bindable as they were before depreciation. Deprecation MUST NOT effect the
 usability of existing Service Instances and Bindings.
 
-The Service Broker SHOULD allow the Platform to continue to
-provision new Service Instances of the deprecated service or plan.
+The Service Broker MUST allow the Platform to continue to provision new Service
+Instances of the deprecated service or plan.
 
 ## Synchronous and Asynchronous Operations
 

--- a/spec.md
+++ b/spec.md
@@ -596,8 +596,6 @@ schema being used.
       "free": false,
       "deprecation": {
         "description": "Don't use this anymore.",
-        "since": "2018-04-20T17:00:00+00:00",
-        "eol": "2020-02-28T08:00:00+00:00",
         "alternatives": [{
             "description": "Use this plan instead.",
             "plan_id": "0f4008b5-XXXX-XXXX-XXXX-dace631cd648"
@@ -613,10 +611,8 @@ schema being used.
 
 | Response Field | Type | Description |
 | --- | --- | --- |
-| description | string | A short description of the deprecation. |
-| since | date string | Date and time when the Service Broker deprecated the service or plan. If specified, this field MUST be an ISO 8601 formatted date and time, with time zone. |
-| eol | date string | Date and time when the Service Broker expects to end-of-life (remove) the service or plan from the catalog. If specified, this field MUST be an ISO 8601 formatted date and time, with time zone. |
-| alternatives | array of [CatalogObjectId](#catalog-object-id-object) objects | An array of services or plans that the Service Broker considers to be good alternatives. |
+| description* | string | A short description of the deprecation. MUST be a non-empty string. |
+| alternatives | array of [CatalogObjectId](#catalog-object-id-object) objects | An array of services or plans that the Service Broker considers to be good alternatives. If present, MUST contain at least one alternative. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -625,8 +621,8 @@ schema being used.
 | Response Field | Type | Description |
 | --- | --- | --- |
 | description | string | A short description to provide contextual information about this catalog object reference. |
-| service_id | string | If present, it MUST be the ID of a service. |
-| plan_id | string | If present, it MUST be the ID of a plan. |
+| service_id | string | If present, it MUST be the ID of a service. If omitted, `plan_id` MUST be present. |
+| plan_id | string | If present, it MUST be the ID of a plan. If omitted, `service_id` MUST be present. |
 
 \* Fields with an asterisk are REQUIRED.
 

--- a/spec.md
+++ b/spec.md
@@ -596,8 +596,8 @@ schema being used.
       "free": false,
       "deprecation": {
         "description": "Don't use this anymore.",
-        "since": "2018-04-20",
-        "eol": "2020-02-28",
+        "since": "2018-04-20T17:00:00+00:00",
+        "eol": "2020-02-28T08:00:00+00:00",
         "alternatives": [{
             "description": "Use this plan instead.",
             "plan_id": "0f4008b5-XXXX-XXXX-XXXX-dace631cd648"
@@ -614,8 +614,8 @@ schema being used.
 | Response Field | Type | Description |
 | --- | --- | --- |
 | description | string | A short description of the deprecation. |
-| since | date string | ISO 8601 formatted date when the Service Broker deprecated the service or plan. |
-| eol | date string | ISO 8601 formatted date when the Service Broker expects to remove the service or plan from the catalog. |
+| since | date string | Date and time when the Service Broker deprecated the service or plan. If specified, it is expected to be an ISO 8601 formatted date and time, with time zone. |
+| eol | date string | Date and time when the Service Broker expects to end-of-life (remove) the service or plan from the catalog. If specified, it is expected to be an ISO 8601 formatted date and time, with time zone. |
 | alternatives | array of [CatalogObjectId](#catalog-object-id-object) objects | An array of services or plans that the Service Broker considers to be good alternatives. |
 
 \* Fields with an asterisk are REQUIRED.

--- a/spec.md
+++ b/spec.md
@@ -429,7 +429,7 @@ how Platforms might expose these values to their users.
 | free | boolean | When false, Service Instances of this plan have a cost. The default is true. |
 | bindable | boolean | Specifies whether Service Instances of the Service Plan can be bound to applications. This field is OPTIONAL. If specified, this takes precedence over the `bindable` attribute of the service. If not specified, the default is derived from the service. |
 | schemas | [Schemas](#schemas-object) | Schema definitions for Service Instances and bindings for the plan. |
-| deprecation | [Deprecation](#deprecation-object) | Contains details of the deprecation status of the plan. This field is OPTIONAL. If ommited, the plan is not deprecated. See [deprecating services and plans](#deprecating-services-and-plans) for more information. |
+| deprecation | [Deprecation](#deprecation-object) | Contains details of the deprecation status of the plan. This field is OPTIONAL. If omitted, the plan is not deprecated. See [deprecating services and plans](#deprecating-services-and-plans) for more information. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -599,11 +599,10 @@ schema being used.
 
 | Response Field | Type | Description |
 | --- | --- | --- |
-| deprecated* | boolean | Indicates that this service or plan is deprecated and will be removed in the future. See [deprecating services and plans](#deprecating-services-and-plans) for more information. |
 | description | string | A short description of the deprecation. |
 | since | date string | ISO 8601 formatted date when the Service Broker deprecated the service or plan. |
 | eol | date string | ISO 8601 formatted date when the Service Broker expects to remove the service or plan from the catalog. |
-| alterntives | array of strings | An array of alterntives services or plans that should be concidered from the broker. This is a list of names. If the debrecated object is a service, these are service names. If the debrecated object is a plan, these are plan names within the same service. |
+| alternatives | array of strings | An array of alternatives services or plans that should be considered from the broker. This is a list of names. If the deprecated object is a service, these are service names. If the deprecated object is a plan, these are plan names within the same service. |
 
 \* Fields with an asterisk are REQUIRED.
 

--- a/spec.md
+++ b/spec.md
@@ -637,7 +637,7 @@ with your Platform to make your services and plans available to end users.
 ### Deprecating services and plans
 
 A Service Broker can signal to a Platform (through the Catalog) that a service
-or plan is deprecated. The Service Broker MAY provide optional messaging and
+or plan is deprecated. The Service Broker MAY provide messaging and
 alternatives for the deprecated service or plan. This gives the Platform the
 opportunity to display meaningful advice to their users to migrate away from
 the deprecated service or plan.

--- a/spec.md
+++ b/spec.md
@@ -292,7 +292,6 @@ use these error codes for the specified failure scenarios.
 | AsyncRequired | This request requires client support for asynchronous service operations. | The query parameter `accepts_incomplete=true` MUST be included the request. |
 | ConcurrencyError | The Service Broker does not support concurrent requests that mutate the same resource. | Clients MUST wait until pending requests have completed for the specified resources. |
 | RequiresApp | The request body is missing the `app_guid` field. | The `app_guid` MUST be included in the request body. |
-| DeprecatedError | The Service Broker does not support provisioning (or updating to) a deprecated service or plan. | Another service or plan should be specified. |
 
 ## Catalog Management
 
@@ -396,7 +395,7 @@ It is therefore RECOMMENDED that implementations avoid such strings.
 | dashboard_client | [DashboardClient](#dashboard-client-object) | Contains the data necessary to activate the Dashboard SSO feature for this service. |
 | plan_updateable | boolean | Whether the service supports upgrade/downgrade for some plans. Please note that the misspelling of the attribute `plan_updatable` as `plan_updateable` was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility. Defaults to false. |
 | plans* | array of [Plan](#plan-object) objects | A list of plans for this service, schema is defined below. MUST contain at least one plan. |
-| deprecation | [Deprecation](#deprecation-object) | Contains details of the deprecation status of the service. This field is OPTIONAL. If omitted, the service is not deprecated. See [deprecating services and plans](#deprecating-services-and-plans) for more information. |
+| deprecation | [Deprecation](#deprecation-object) | Contains details of the deprecation status of the service. This field is OPTIONAL. If specified, the service is deprecated. See [deprecating services and plans](#deprecating-services-and-plans) for more information. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -429,7 +428,7 @@ how Platforms might expose these values to their users.
 | free | boolean | When false, Service Instances of this plan have a cost. The default is true. |
 | bindable | boolean | Specifies whether Service Instances of the Service Plan can be bound to applications. This field is OPTIONAL. If specified, this takes precedence over the `bindable` attribute of the service. If not specified, the default is derived from the service. |
 | schemas | [Schemas](#schemas-object) | Schema definitions for Service Instances and bindings for the plan. |
-| deprecation | [Deprecation](#deprecation-object) | Contains details of the deprecation status of the plan. This field is OPTIONAL. If omitted, the plan is not deprecated. See [deprecating services and plans](#deprecating-services-and-plans) for more information. |
+| deprecation | [Deprecation](#deprecation-object) | Contains details of the deprecation status of the plan. This field is OPTIONAL. If specified, the plan is deprecated. See [deprecating services and plans](#deprecating-services-and-plans) for more information. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -590,6 +589,12 @@ schema being used.
           "40 concurrent connections"
         ]
       }
+    }, {
+      "name": "fake-deprecated-plan",
+      "id": "009aba-XXXX-XXXX-XXXX-dace631cd648",
+      "description": "This is deprecated.",
+      "free": false,
+      "deprecation": {}
     }]
   }]
 }
@@ -620,14 +625,12 @@ alternatives for the deprecated service or plan. This gives the Platform the
 opportunity to display meaningful advice to their users to migrate away from
 the deprecated service or plan.
 
-Service Brokers MUST allow existing Service Instances to be updated as they
-were before depreciation. Service Brokers MAY block provisioning of a Service
-Instance using a deprecated service or plan, or block updating an existing
-Service Instance to a deprecated plan by return error code `DeprecatedError`
-(see [Service Broker Errors](#service-broker-errors)).
+Service Brokers MUST allow existing Service Instances to be updated and
+bindable as they were before depreciation. Deprecation MUST NOT effect the
+usability of existing Service Instances and Bindings.
 
 The Service Broker SHOULD allow the Platform to continue to
-provision new Service Instances of the deprecated service or plan. 
+provision new Service Instances of the deprecated service or plan.
 
 ## Synchronous and Asynchronous Operations
 

--- a/spec.md
+++ b/spec.md
@@ -395,7 +395,7 @@ It is therefore RECOMMENDED that implementations avoid such strings.
 | dashboard_client | [DashboardClient](#dashboard-client-object) | Contains the data necessary to activate the Dashboard SSO feature for this service. |
 | plan_updateable | boolean | Whether the service supports upgrade/downgrade for some plans. Please note that the misspelling of the attribute `plan_updatable` as `plan_updateable` was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility. Defaults to false. |
 | plans* | array of [Plan](#plan-object) objects | A list of plans for this service, schema is defined below. MUST contain at least one plan. |
-| deprecation | [Deprecation](#deprecation-object) | Contains details of the deprecation status of the service. This field is OPTIONAL. If specified, the service is deprecated. See [deprecating services and plans](#deprecating-services-and-plans) for more information. |
+| deprecation | [Deprecation](#deprecation-object) | Contains details of the deprecation status of the service. If specified, the service is deprecated. See [deprecating services and plans](#deprecating-services-and-plans) for more information. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -426,9 +426,9 @@ how Platforms might expose these values to their users.
 | description* | string | A short description of the plan. MUST be a non-empty string. |
 | metadata | object | An opaque object of metadata for a Service Plan. It is expected that Platforms will treat this as a blob. Note that there are [conventions](profile.md#service-metadata) in existing Service Brokers and Platforms for fields that aid in the display of catalog data. |
 | free | boolean | When false, Service Instances of this plan have a cost. The default is true. |
-| bindable | boolean | Specifies whether Service Instances of the Service Plan can be bound to applications. This field is OPTIONAL. If specified, this takes precedence over the `bindable` attribute of the service. If not specified, the default is derived from the service. |
+| bindable | boolean | Specifies whether Service Instances of the Service Plan can be bound to applications. If specified, this takes precedence over the `bindable` attribute of the service. If not specified, the default is derived from the service. |
 | schemas | [Schemas](#schemas-object) | Schema definitions for Service Instances and bindings for the plan. |
-| deprecation | [Deprecation](#deprecation-object) | Contains details of the deprecation status of the plan. This field is OPTIONAL. If specified, the plan is deprecated. See [deprecating services and plans](#deprecating-services-and-plans) for more information. |
+| deprecation | [Deprecation](#deprecation-object) | Contains details of the deprecation status of the plan. If specified, the plan is deprecated. See [deprecating services and plans](#deprecating-services-and-plans) for more information. |
 
 \* Fields with an asterisk are REQUIRED.
 

--- a/spec.md
+++ b/spec.md
@@ -628,6 +628,8 @@ schema being used.
 | service_id | string | If present, it MUST be the ID of a service. |
 | plan_id | string | If present, it MUST be the ID of a plan. |
 
+\* Fields with an asterisk are REQUIRED.
+
 ### Adding a Service Broker to the Platform
 
 After implementing the first endpoint `GET /v2/catalog` documented

--- a/spec.md
+++ b/spec.md
@@ -292,7 +292,7 @@ use these error codes for the specified failure scenarios.
 | AsyncRequired | This request requires client support for asynchronous service operations. | The query parameter `accepts_incomplete=true` MUST be included the request. |
 | ConcurrencyError | The Service Broker does not support concurrent requests that mutate the same resource. | Clients MUST wait until pending requests have completed for the specified resources. |
 | RequiresApp | The request body is missing the `app_guid` field. | The `app_guid` MUST be included in the request body. |
-| DeprecatedError | The Service Broker does not support provisiong (or updating to) a deprecated service or plan. | Another service or plan should be specified. |
+| DeprecatedError | The Service Broker does not support provisioning (or updating to) a deprecated service or plan. | Another service or plan should be specified. |
 
 ## Catalog Management
 
@@ -396,7 +396,7 @@ It is therefore RECOMMENDED that implementations avoid such strings.
 | dashboard_client | [DashboardClient](#dashboard-client-object) | Contains the data necessary to activate the Dashboard SSO feature for this service. |
 | plan_updateable | boolean | Whether the service supports upgrade/downgrade for some plans. Please note that the misspelling of the attribute `plan_updatable` as `plan_updateable` was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility. Defaults to false. |
 | plans* | array of [Plan](#plan-object) objects | A list of plans for this service, schema is defined below. MUST contain at least one plan. |
-| deprecation | [Deprecation](#deprecation-object) | Contains details of the deprecation status of the service. This field is OPTIONAL. If ommited, the service is not deprecated. See [deprecating services and plans](#deprecating-services-and-plans) for more information. |
+| deprecation | [Deprecation](#deprecation-object) | Contains details of the deprecation status of the service. This field is OPTIONAL. If omitted, the service is not deprecated. See [deprecating services and plans](#deprecating-services-and-plans) for more information. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -413,7 +413,7 @@ how Platforms might expose these values to their users.
 
 | Response Field | Type | Description |
 | --- | --- | --- |
-| id | string | The id of the Oauth client that the dashboard will use. If present, MUST be a non-empty string. |
+| id | string | The id of the OAuth client that the dashboard will use. If present, MUST be a non-empty string. |
 | secret | string | A secret for the dashboard client. If present, MUST be a non-empty string. |
 | redirect_uri | string | A URI for the service dashboard. Validated by the OAuth token server when the dashboard requests a token. |
 
@@ -617,12 +617,12 @@ with your Platform to make your services and plans available to end users.
 
 A Service Broker can signal to a Platform (through the Catalog) that a service
 or plan is deprecated. The Service Broker MAY provide optional messaging and
-alterntives for the deprecated service or plan. This gives the Platform the
+alternatives for the deprecated service or plan. This gives the Platform the
 opportunity to display meaningful advice to their users to migrate away from
 the deprecated service or plan.
 
 Service Brokers MUST allow existing Service Instances to be updated as they
-were before deprecration. Service Brokers MAY block provisioning of a Service
+were before depreciation. Service Brokers MAY block provisioning of a Service
 Instance using a deprecated service or plan, or block updating an existing
 Service Instance to a deprecated plan by return error code `DeprecatedError`
 (see [Service Broker Errors](#service-broker-errors)).
@@ -667,7 +667,7 @@ update, and deprovision.
 
 For a Service Broker to return an asynchronous response, the query parameter
 `accepts_incomplete=true` MUST be included the request. If the parameter is not
-included or is set to `false`, and the Service Broker cannot fulfil the request
+included or is set to `false`, and the Service Broker cannot fulfill the request
 synchronously (guaranteeing that the operation is complete on response), then
 the Service Broker SHOULD reject the request with the status code `422
 Unprocessable Entity` and a response body containing error code

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -409,6 +409,8 @@ definitions:
         $ref: '#/definitions/Deprecation'
   Deprecation:
     type: object
+    required:
+      - description
     properties:
       description:
         type: string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -372,6 +372,8 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/Plan'
+      deprecation:
+        $ref: '#/definitions/Deprecation'
   DashboardClient:
     type: object
     properties:
@@ -403,6 +405,26 @@ definitions:
         type: boolean
       schemas:
         $ref: '#/definitions/SchemasObject'
+      deprecation:
+        $ref: '#/definitions/Deprecation'
+  Deprecation:
+    type: object
+    properties:
+      description:
+        type: string
+      alternatives:
+        type: array
+        items:
+          $ref: '#/definitions/CatalogObject'
+  CatalogObject:
+    type: object
+    properties:
+      description:
+        type: string
+      service_id:
+        type: string
+      plan_id:
+        type: string
   SchemasObject:
     type: object
     properties:


### PR DESCRIPTION
A follow-up implementation PR to the [short proposal](https://docs.google.com/document/d/1pcA-6WFtFNspghB4FYN3Udw4t8q4M1WQJzEWamvrlC8/view#) to add deprecation support to OSBAPI.

Please review and provide feedback. I pivoted off of the[ original PR](https://github.com/openservicebrokerapi/servicebroker/pull/311) by @pmorie but I dropped the language around asking Brokers to not change service names. That can be added as guidance as a follow-up if it remains an issue.