### PR TITLE
Make identity header naming consistent

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -224,12 +224,12 @@ will need to provide this identification information to the Service Broker on
 each request. Platforms MAY support this feature, and if they do, they MUST
 adhere to the following:
 - For any OSBAPI request that is the result of an action taken by a Platform's
-  user, there MUST be an associated `OriginatingIdentity` header on that HTTP
+  user, there MUST be an associated `X-Broker-API-Originating-Identity` header on that HTTP
   request.
 - Any OSBAPI request that is not associated with an action from a Platform's
   user, such as the Platform refetching the catalog, MAY exclude the header from
   that HTTP request.
-- If present on a request, the `OriginatingIdentity` header MUST contain the
+- If present on a request, the `X-Broker-API-Originating-Identity` header MUST contain the
   identify information for the Platform's user that took the action to cause the
   request to be sent.
 


### PR DESCRIPTION
Another small fixup around the `Originating-Identity` header. Might seem trivial but as I got to this section I wasn't initially sure which was the "correct" version, until I got to later sections where the hyphen is repeated. Might just help to clarify this by being consistent.