### PR TITLE
[WIP] Add current version to catalog and allows the version to be updated

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -430,6 +430,7 @@ how Platforms might expose these values to their users.
 | free | boolean | When false, Service Instances of this plan have a cost. The default is true. |
 | bindable | boolean | Specifies whether Service Instances of the Service Plan can be bound to applications. This field is OPTIONAL. If specified, this takes precedence over the `bindable` attribute of the service. If not specified, the default is derived from the service. |
 | schemas | [Schemas](#schemas-object) | Schema definitions for Service Instances and bindings for the plan. |
+| current_service_instance_version | object | A free-form hash that represents the version of the service instance that the plan will deploy. MAY be used by the platform to update previously deployed service instances to the latest version of the service instance. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -994,6 +995,7 @@ The following HTTP Headers are defined for this operation:
 | service_id* | string | MUST be the ID of a service from the catalog for this Service Broker. |
 | plan_id | string | If present, MUST be the ID of a plan from the service that has been requested. If this field is not present in the request message, then the Service Broker MUST NOT change the plan of the instance as a result of this request. |
 | parameters | object | Configuration parameters for the Service Instance. Service Brokers SHOULD ensure that the client has provided valid configuration parameters and values for the operation. See "Note" below. |
+| version | object | A free-form hash that represents the version to which the service instance should be updated to. Service Brokers SHOULD ensure that the client has provided a version supported by the broker. |
 | previous_values | [PreviousValues](#previous-values-object) | Information about the Service Instance prior to the update. |
 
 \* Fields with an asterisk are REQUIRED.


### PR DESCRIPTION
A followup from the F2F, this PR is about allowing service brokers to enable platforms to trigger 'upgrades' on instances. This has been implemented by adding the concept of a "version" for a plan.

There are two problems being tackled here: 
1. How does the broker inform the platform that a new version is available for upgrades.
1. How can the client trigger an upgrade, to update the service instance to the new version

[Original proposal](https://docs.google.com/document/d/1ql0pNDGdxD1qlD1gYRytz7ZfGJT0XlO-Ol-hr-h7g-Y/edit#)(might be slightly out of date, but conveys intent) 