### PR TITLE
Make explicit that broker authors may not return some or all params

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1040,7 +1040,7 @@ For success responses, the following fields are defined:
 | dashboard_url | string | The URL of a web-based management user interface for the Service Instance; we refer to this as a service dashboard. The URL MUST contain enough information for the dashboard to identify the resource being accessed (`9189kdfsk0vfnku` in the example below). Note: a Service Broker that wishes to return `dashboard_url` for a Service Instance MUST return it with the initial response to the provision request, even if the service is provisioned asynchronously. |
 | parameters | object | Configuration parameters for the Service Instance. |
 
-Service Brokers MAY choose to not return parameters when a Service Instance is fetched - for example,
+Service Brokers MAY choose to not return some or all parameters when a Service Instance is fetched - for example,
 if it contains sensitive information.
 
 ```
@@ -1510,7 +1510,7 @@ For success responses, the following fields are defined:
 | volume_mounts | array of [VolumeMount](#volume-mount-object) objects | An array of configuration for mounting volumes. `"requires":["volume_mount"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
 | parameters | object | Configuration parameters for the Service Binding. |
 
-Service Brokers MAY choose to not return parameters when a Service Binding is fetched - for example,
+Service Brokers MAY choose to not return some or all parameters when a Service Binding is fetched - for example,
 if it contains sensitive information.
 
 ```


### PR DESCRIPTION
Per discussion around the last PR, just make this explicit