### PR TITLE
Clarify X-Broker-API-Originating-Identity

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -208,14 +208,19 @@ will need to provide this identification information to the Service Broker on
 each request. Platforms MAY support this feature, and if they do, they MUST
 adhere to the following:
 - For any OSBAPI request that is the result of an action taken by a Platform's
-  user, there MUST be an associated `X-Broker-API-Originating-Identity` header on that HTTP
-  request.
+  user, there MUST be an associated `X-Broker-API-Originating-Identity` header on 
+  that HTTP request.
 - Any OSBAPI request that is not associated with an action from a Platform's
   user, such as the Platform refetching the catalog, MAY exclude the header from
   that HTTP request.
-- If present on a request, the `X-Broker-API-Originating-Identity` header MUST contain the
-  identify information for the Platform's user that took the action to cause the
-  request to be sent.
+- If present on a request, the `X-Broker-API-Originating-Identity` header 
+  MUST contain the identify information for the Platform's user that took 
+  the action to cause the request to be sent.
+
+If the Platform chooses to group multiple end-user operations into one request
+to the Broker, then the identity information associated with that one request
+MUST accurately reflect the desired indentity associated for each individual
+change.
 
 The format of the header MUST be:
 


### PR DESCRIPTION
From #476 

Add a section to clarify that originating identity for batched requests of multiple users is beyond the scope of the specification - the broker will treat the provided ID as the definitive one.