### PR TITLE
Fix minor typo around broker clean up upon failure

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -794,7 +794,7 @@ If the response contains `"state": "failed"` then the Platform MUST send a
 deprovision request to the Service Broker to prevent an orphan being created on
 the Service Broker. However, while the Platform will attempt
 to send a deprovision request, Service Brokers MAY automatically delete
-any resources associated with the failed bind request on their own.
+any resources associated with the failed provisioning request on their own.
 
 ## Polling Last Operation for Service Bindings
 


### PR DESCRIPTION
Inconsistent wording between polling service instance provisioning and recovering from failed binding.

@duglin suspecting a previous copy/paste mistake in https://github.com/openservicebrokerapi/servicebroker/commit/af53c22bcc2c65392fc527d3a00e3314c3f588b9