### PR TITLE
Document `metadata.shareable` type as boolean

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -429,7 +429,7 @@ specific behaviour.
 
 | Broker API Field | Type | Description |
 | --- | --- | --- |
-| metadata.shareable | string | Allows Service Instances to be shared across orgs and spaces. |
+| metadata.shareable | boolean | Allows Service Instances to be shared across orgs and spaces. |
 
 ## Catalog Extensions
 


### PR DESCRIPTION
Before this change `metadata.shareable` was wrongly documented as
`string` typed attribute.

This change fixes the documented type of the attribute.