### PR TITLE
Add a delay to polling response

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -281,6 +281,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LastOperationResource'
+          headers:
+            - $ref: '#/components/parameters/RetryAfter'
         '400':
           description: Bad Request
           content:
@@ -336,6 +338,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/LastOperationResource'
+          headers:
+            - $ref: '#/components/parameters/RetryAfter'
         '400':
           description: Bad Request
           content:
@@ -530,6 +534,14 @@ components:
       name: X-Broker-API-Originating-Identity
       in: header
       description: identity of the user that initiated the request from the Platform
+      schema:
+        type: string
+
+    RetryAfter:
+      name: Retry-After
+      in: header
+      description: Indicates when to retry the request
+      require: false
       schema:
         type: string
 

--- a/spec.md
+++ b/spec.md
@@ -770,6 +770,7 @@ For success responses, the following fields are defined:
 | --- | --- | --- |
 | state* | string | Valid values are `in progress`, `succeeded`, and `failed`. While `"state": "in progress"`, the Platform SHOULD continue polling. A response with `"state": "succeeded"` or `"state": "failed"` MUST cause the Platform to cease polling. |
 | description | string | A user-facing message that can be used to tell the user details about the status of the operation. |
+| poll_delay | integer | The time, in seconds, that a Platform SHOULD wait before sending another last_operation request. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -785,6 +786,11 @@ deprovision request to the Service Broker to prevent an orphan being created on
 the Service Broker. However, while the Platform will attempt
 to send a deprovision request, Service Brokers MAY automatically delete
 any resources associated with the failed provisioning request on their own.
+
+If the Service Broker is able to estimate how long it will be before the
+Service Instance will be fully provisioned, it MAY include a `poll_delay`
+field in the response message to prevent unnecessary, and premature, calls
+to the `last_operation` endpoint.
 
 ## Polling Last Operation for Service Bindings
 
@@ -848,6 +854,7 @@ For success responses, the following fields are defined:
 | --- | --- | --- |
 | state* | string | Valid values are `in progress`, `succeeded`, and `failed`. While `"state": "in progress"`, the Platform SHOULD continue polling. A response with `"state": "succeeded"` or `"state": "failed"` MUST cause the Platform to cease polling. |
 | description | string | A user-facing message that can be used to tell the user details about the status of the operation. |
+| poll_delay | integer | The time, in seconds, that a Platform SHOULD wait before sending another last_operation request. |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -861,6 +868,11 @@ For success responses, the following fields are defined:
 If the response contains `"state": "failed"` then the Platform MUST send an
 unbind request to the Service Broker to prevent an orphan being created on
 the Service Broker.
+
+If the Service Broker is able to estimate how long it will be before the
+Service Binding will be ready, it MAY include a `poll_delay`
+field in the response message to prevent unnecessary, and premature, calls
+to the `last_operation` endpoint.
 
 ## Polling Interval and Duration
 

--- a/spec.md
+++ b/spec.md
@@ -770,7 +770,12 @@ For success responses, the following fields are defined:
 | --- | --- | --- |
 | state* | string | Valid values are `in progress`, `succeeded`, and `failed`. While `"state": "in progress"`, the Platform SHOULD continue polling. A response with `"state": "succeeded"` or `"state": "failed"` MUST cause the Platform to cease polling. |
 | description | string | A user-facing message that can be used to tell the user details about the status of the operation. |
-| poll_delay | integer | The time, in seconds, that a Platform SHOULD wait before sending another last_operation request. |
+
+The response MAY also include the `Retry-After` HTTP header. This header will
+indicate how long the Platform SHOULD wait before polling again and is
+intended to prevent unnecessary, and premature, calls to the `last_operation`
+endpoint. It is RECOMMENDED that the header include a duration rather than a
+timestamp.
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -786,11 +791,6 @@ deprovision request to the Service Broker to prevent an orphan being created on
 the Service Broker. However, while the Platform will attempt
 to send a deprovision request, Service Brokers MAY automatically delete
 any resources associated with the failed provisioning request on their own.
-
-If the Service Broker is able to estimate how long it will be before the
-Service Instance will be fully provisioned, it MAY include a `poll_delay`
-field in the response message to prevent unnecessary, and premature, calls
-to the `last_operation` endpoint.
 
 ## Polling Last Operation for Service Bindings
 
@@ -854,7 +854,12 @@ For success responses, the following fields are defined:
 | --- | --- | --- |
 | state* | string | Valid values are `in progress`, `succeeded`, and `failed`. While `"state": "in progress"`, the Platform SHOULD continue polling. A response with `"state": "succeeded"` or `"state": "failed"` MUST cause the Platform to cease polling. |
 | description | string | A user-facing message that can be used to tell the user details about the status of the operation. |
-| poll_delay | integer | The time, in seconds, that a Platform SHOULD wait before sending another last_operation request. |
+
+The response MAY also include the `Retry-After` HTTP header. This header will
+indicate how long the Platform SHOULD wait before polling again and is
+intended to prevent unnecessary, and premature, calls to the `last_operation`
+endpoint. It is RECOMMENDED that the header include a duration rather than a
+timestamp.
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -868,11 +873,6 @@ For success responses, the following fields are defined:
 If the response contains `"state": "failed"` then the Platform MUST send an
 unbind request to the Service Broker to prevent an orphan being created on
 the Service Broker.
-
-If the Service Broker is able to estimate how long it will be before the
-Service Binding will be ready, it MAY include a `poll_delay`
-field in the response message to prevent unnecessary, and premature, calls
-to the `last_operation` endpoint.
 
 ## Polling Interval and Duration
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -569,6 +569,8 @@ definitions:
           - failed
       description:
         type: string
+      poll_delay:
+        type: integer
   ServiceBindingResource:
     type: object
     properties:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -194,6 +194,8 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/LastOperationResource'
+          headers:
+            - $ref: '#/parameters/RetryAfter'
         '400':
           description: Bad Request
           schema:
@@ -232,6 +234,8 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/LastOperationResource'
+          headers:
+            - $ref: '#/parameters/RetryAfter'
         '400':
           description: Bad Request
           schema:
@@ -343,6 +347,12 @@ parameters:
     name: X-Broker-API-Originating-Identity
     in: header
     description: identity of the user that initiated the request from the Platform
+    type: string
+  RetryAfter:
+    name: Retry-After
+    in: header
+    description: Indicates when to retry the request
+    required: false
     type: string
   instance_id:
     name: instance_id
@@ -569,8 +579,6 @@ definitions:
           - failed
       description:
         type: string
-      poll_delay:
-        type: integer
   ServiceBindingResource:
     type: object
     properties:


### PR DESCRIPTION
First part of #606

Adds a `poll_delay` field to the `last_operation` response to allow a
Broker to tell a Platform to back-off on its polling

Signed-off-by: Doug Davis <dug@us.ibm.com>