### PR TITLE
Dashboard client ID and secret are required in CF

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -446,9 +446,11 @@ Service Brokers MAY also expose the following fields to enable Platform specific
 
 | Response Field | Type | Description |
 | --- | --- | --- |
-| id | string | The id of the OAuth client that the dashboard will use. If present, MUST be a non-empty string. |
-| secret | string | A secret for the dashboard client. If present, MUST be a non-empty string. |
+| id* | string | The id of the OAuth client that the dashboard will use. If present, MUST be a non-empty string. |
+| secret* | string | A secret for the dashboard client. If present, MUST be a non-empty string. |
 | redirect_uri | string | A URI for the service dashboard. Validated by the OAuth token server when the dashboard requests a token. |
+
+\* Fields with an asterisk are REQUIRED.
 
 #### Example Catalog
 


### PR DESCRIPTION
We checked the behavior of `dashboard_client` in CF, and it turns out both the `dashboard_client.id` and `dashboard_client.secret` fields are required. This is technically a breaking change, but we want to bring the spec in line with actual behavior. 
