### PR TITLE
Add org and space name to CF context object

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -174,6 +174,20 @@ deployment:
   ```
   "organization_guid": "1113aa0-124e-4af2-1526-6bfacf61b111"
   ```
+  - `organization_name`
+
+    Version: 2.15
+
+    The name of the organization that a Service Instance is associated with.
+    Note that the name of an organization in Cloud Foundry MAY be changed.
+    This property MUST be a non-empty string serialized as follows:
+    ```
+    "organization_name": "organization-name-here"
+    ```
+    For example:
+    ```
+    "organization_name": "system"
+    ```
 
 - `space_guid`
 
@@ -189,14 +203,29 @@ deployment:
   "space_guid": "aaaa1234-da91-4f12-8ffa-b51d0336aaaa"
   ```
 
+- `space_name`
+
+  Version: 2.15
+
+  The name of the space that a Service Instance is associated with.
+  Note that the name of a space in Cloud Foundry MAY be changed.
+  This property MUST be a non-empty string serialized as follows:
+  ```
+  "space_name": "space-name-here"
+  ```
+  For example:
+  ```
+  "space_name": "development"
+  ```
+
 The following table specifies which properties will appear in each API.
 All properties specified are REQUIRED unless otherwise noted.
 
 | Request API | Properties |
 | --- | --- |
-| `PUT /v2/service_instances/:instance_id` | `organization_guid`, `space_guid` |
-| `PATCH /v2/service_instances/:instance_id` | `organization_guid`, `space_guid` |
-| `PUT /v2/service_instances/:instance_id/service_bindings/:binding_id` | `organization_guid`, `space_guid` |
+| `PUT /v2/service_instances/:instance_id` | `organization_guid`, `organization_name`, `space_guid`, `space_name` |
+| `PATCH /v2/service_instances/:instance_id` | `organization_guid`, `organization_name`, `space_guid`, `space_name` |
+| `PUT /v2/service_instances/:instance_id/service_bindings/:binding_id` | `organization_guid`, `organization_name`, `space_guid`, `space_name` |
 
 The following example shows a `context` object that might appear as part of a
 Cloud Foundry API call:
@@ -229,7 +258,6 @@ The following properties are defined for usage within a Kubernetes deployment:
   ```
   "namespace": "testing"
   ```
-
 
 - `clusterid`
 


### PR DESCRIPTION
This would be useful for Service Broker authors who want to, for example, display the org/space name where a Service Instance resides in a Cloud Foundry environment. This provides a better UX than using the org/space GUID, with the caveat that the name may be changed.