### PR TITLE
Service Specific Async Polling Timeout

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -454,7 +454,6 @@ It is therefore RECOMMENDED that implementations avoid such strings.
 | dashboard_client | [DashboardClient](profile.md#dashboard-client-object) | A Cloud Foundry extension described in [Catalog Extensions](profile.md#catalog-extensions). Contains the data necessary to activate the Dashboard SSO feature for this service. |
 | plan_updateable | boolean | Whether the Service Offering supports upgrade/downgrade for Service Plans by default. Service Plans can override this field (see [Service Plan](#service-plan-object)). Please note that the misspelling of the attribute `plan_updatable` as `plan_updateable` was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility. Defaults to false. |
 | plans* | array of [Service Plan](#service-plan-object) objects | A list of Service Plans for this Service Offering, schema is defined below. MUST contain at least one Service Plan. |
-| maximum_polling_duration | integer | A duration, in minutes, that the Platform SHOULD use as the Service's [maximum polling duration](#polling-interval-and-duration). |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -479,6 +478,7 @@ how Platforms might expose these values to their users.
 | bindable | boolean | Specifies whether Service Instances of the Service Plan can be bound to applications. This field is OPTIONAL. If specified, this takes precedence over the `bindable` attribute of the Service Offering. If not specified, the default is derived from the Service Offering. |
 | plan_updateable | boolean | Whether the Plan supports upgrade/downgrade/sidegrade to another version. This field is OPTIONAL. If specificed, this takes precedence over the Service Offering's `plan_updateable` field. If not specified, the default is derived from the Service Offering. Please note that the attribute is intentionally misspelled as `plan_updateable` for legacy reasons. |
 | schemas | [Schemas](#schemas-object) | Schema definitions for Service Instances and Service Bindings for the Service Plan. |
+| maximum_polling_duration | integer | A duration, in minutes, that the Platform SHOULD use as the Service's [maximum polling duration](#polling-interval-and-duration). |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -868,8 +868,8 @@ the Service Broker.
 The frequency and maximum duration of polling MAY vary by Platform.
 Additionally, Service Brokers can specify the maximum time a Platform SHOULD
 poll via the `maximum_polling_duration` field returned by the
-[Catalog](#catalog-management) endpoint. If either the Platform or Service
-Broker's maximum polling duration is reached, the Platform SHOULD cease polling
+[Service Plan Object](#service-plan-object). If either the Platform or Service
+Plan's maximum polling duration is reached, the Platform SHOULD cease polling
 and the operation state MUST be considered `failed`.
 
 ## Provisioning

--- a/spec.md
+++ b/spec.md
@@ -865,10 +865,12 @@ the Service Broker.
 
 ## Polling Interval and Duration
 
-The frequency and maximum duration of polling MAY vary by Platform. Additionally, Service Brokers
-can specify the maximum time a Platform SHOULD poll via the `maximum_polling_duration` field returned
-by the [Catalog](#catalog-management) endpoint. If either the Platform or Service Broker's maximum polling
-duration is reached, the Platform SHOULD cease polling and the operation state MUST be considered `failed`.
+The frequency and maximum duration of polling MAY vary by Platform.
+Additionally, Service Brokers can specify the maximum time a Platform SHOULD
+poll via the `maximum_polling_duration` field returned by the
+[Catalog](#catalog-management) endpoint. If either the Platform or Service
+Broker's maximum polling duration is reached, the Platform SHOULD cease polling
+and the operation state MUST be considered `failed`.
 
 ## Provisioning
 

--- a/spec.md
+++ b/spec.md
@@ -454,7 +454,7 @@ It is therefore RECOMMENDED that implementations avoid such strings.
 | dashboard_client | [DashboardClient](profile.md#dashboard-client-object) | A Cloud Foundry extension described in [Catalog Extensions](profile.md#catalog-extensions). Contains the data necessary to activate the Dashboard SSO feature for this service. |
 | plan_updateable | boolean | Whether the Service Offering supports upgrade/downgrade for Service Plans by default. Service Plans can override this field (see [Service Plan](#service-plan-object)). Please note that the misspelling of the attribute `plan_updatable` as `plan_updateable` was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility. Defaults to false. |
 | plans* | array of [Service Plan](#service-plan-object) objects | A list of Service Plans for this Service Offering, schema is defined below. MUST contain at least one Service Plan. |
-| maximum_polling_duration | integer | A duration, in minutes, that the platform SHOULD use as the service's [maximum polling duration](#polling-interval-and-duration) |
+| maximum_polling_duration | integer | A duration, in minutes, that the platform SHOULD use as the service's [maximum polling duration](#polling-interval-and-duration). |
 
 \* Fields with an asterisk are REQUIRED.
 

--- a/spec.md
+++ b/spec.md
@@ -454,7 +454,7 @@ It is therefore RECOMMENDED that implementations avoid such strings.
 | dashboard_client | [DashboardClient](profile.md#dashboard-client-object) | A Cloud Foundry extension described in [Catalog Extensions](profile.md#catalog-extensions). Contains the data necessary to activate the Dashboard SSO feature for this service. |
 | plan_updateable | boolean | Whether the Service Offering supports upgrade/downgrade for Service Plans by default. Service Plans can override this field (see [Service Plan](#service-plan-object)). Please note that the misspelling of the attribute `plan_updatable` as `plan_updateable` was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility. Defaults to false. |
 | plans* | array of [Service Plan](#service-plan-object) objects | A list of Service Plans for this Service Offering, schema is defined below. MUST contain at least one Service Plan. |
-| maximum_polling_duration | integer | A duration, in minutes, that the platform SHOULD use as the service's [maximum polling duration](#polling-interval-and-duration). |
+| maximum_polling_duration | integer | A duration, in minutes, that the Platform SHOULD use as the Service's [maximum polling duration](#polling-interval-and-duration). |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -865,13 +865,10 @@ the Service Broker.
 
 ## Polling Interval and Duration
 
-The frequency and maximum duration of polling MAY vary by Platform client. If
-a Platform has a max polling duration and this limit is reached, the Platform
-MUST cease polling and the operation state MUST be considered `failed`.
-
-If a Service Offering declares a `maximum_polling_duration`
-in the [Catalog](#catalog-management)
-endpoint, that value SHOULD be used by the platform as its max polling duration.
+The frequency and maximum duration of polling MAY vary by Platform. Additionally, Service Brokers
+can specify the maximum time a Platform SHOULD poll via the `maximum_polling_duration` field returned
+by the [Catalog](#catalog-management) endpoint. If either the Platform or Service Broker's maximum polling
+duration is reached, the Platform SHOULD cease polling and the operation state MUST be considered `failed`.
 
 ## Provisioning
 

--- a/spec.md
+++ b/spec.md
@@ -478,7 +478,7 @@ how Platforms might expose these values to their users.
 | bindable | boolean | Specifies whether Service Instances of the Service Plan can be bound to applications. This field is OPTIONAL. If specified, this takes precedence over the `bindable` attribute of the Service Offering. If not specified, the default is derived from the Service Offering. |
 | plan_updateable | boolean | Whether the Plan supports upgrade/downgrade/sidegrade to another version. This field is OPTIONAL. If specificed, this takes precedence over the Service Offering's `plan_updateable` field. If not specified, the default is derived from the Service Offering. Please note that the attribute is intentionally misspelled as `plan_updateable` for legacy reasons. |
 | schemas | [Schemas](#schemas-object) | Schema definitions for Service Instances and Service Bindings for the Service Plan. |
-| maximum_polling_duration | integer | A duration, in minutes, that the Platform SHOULD use as the Service's [maximum polling duration](#polling-interval-and-duration). |
+| maximum_polling_duration | integer | A duration, in seconds, that the Platform SHOULD use as the Service's [maximum polling duration](#polling-interval-and-duration). |
 
 \* Fields with an asterisk are REQUIRED.
 

--- a/spec.md
+++ b/spec.md
@@ -454,6 +454,7 @@ It is therefore RECOMMENDED that implementations avoid such strings.
 | dashboard_client | [DashboardClient](profile.md#dashboard-client-object) | A Cloud Foundry extension described in [Catalog Extensions](profile.md#catalog-extensions). Contains the data necessary to activate the Dashboard SSO feature for this service. |
 | plan_updateable | boolean | Whether the Service Offering supports upgrade/downgrade for Service Plans by default. Service Plans can override this field (see [Service Plan](#service-plan-object)). Please note that the misspelling of the attribute `plan_updatable` as `plan_updateable` was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility. Defaults to false. |
 | plans* | array of [Service Plan](#service-plan-object) objects | A list of Service Plans for this Service Offering, schema is defined below. MUST contain at least one Service Plan. |
+| maximum_polling_duration | integer | A duration, in minutes, that the platform SHOULD use as the service's [maximum polling duration](#polling-interval-and-duration) |
 
 \* Fields with an asterisk are REQUIRED.
 
@@ -867,6 +868,10 @@ the Service Broker.
 The frequency and maximum duration of polling MAY vary by Platform client. If
 a Platform has a max polling duration and this limit is reached, the Platform
 MUST cease polling and the operation state MUST be considered `failed`.
+
+If a Service Offering declares a `maximum_polling_duration`
+in the [Catalog](#catalog-management)
+endpoint, that value SHOULD be used by the platform as its max polling duration.
 
 ## Provisioning
 


### PR DESCRIPTION
Closes #625

Adds a timeout value (at the catalog level for a service), that the platform SHOULD use as a hint to give up and declare failure.

See #625 for additional background details.