### PR TITLE
Add binding endpoints

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -524,7 +524,7 @@ components:
       required: true
       schema:
         type: string
-      default: '2.13'
+        default: '2.13'
 
     OriginatingIdentity:
       name: X-Broker-API-Originating-Identity
@@ -759,6 +759,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ServiceBindingVolumeMount'
+        endpoints:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceBindingEndpoint'
         parameters:
           $ref: '#/components/schemas/Object'
 
@@ -803,6 +807,30 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ServiceBindingVolumeMount'
+        endpoints:
+          type: array
+          items:
+            $ref: '#/components/schemas/ServiceBindingEndpoint'
+
+    ServiceBindingEndpoint:
+      type: object
+      required:
+      - host
+      - ports
+      properties:
+        host:
+          type: string
+        ports:
+          type: array
+          items:
+            type: string
+        protocol:
+          type: string
+          enum:
+          - 'tcp'
+          - 'udp'
+          - 'all'
+          default: 'tcp'
 
     ServiceBindingVolumeMount:
       type: object

--- a/spec.md
+++ b/spec.md
@@ -1369,7 +1369,7 @@ For `200 OK` and `201 Created` response codes, the following fields are defined:
 | syslog_drain_url | string | A URL to which logs MUST be streamed. `"requires":["syslog_drain"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
 | route_service_url | string | A URL to which the Platform MUST proxy requests for the address sent with `bind_resource.route` in the request body. `"requires":["route_forwarding"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
 | volume_mounts | array of [VolumeMount](#volume-mount-object) objects | An array of configuration for remote storage devices to be mounted into an application container filesystem. `"requires":["volume_mount"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
-| endpoints | array of [Endpoint](#endpoint-object) objects | The network endpoints that the Application uses to connect to the Service Instance. All Service Instance endpoints that relevant for the Application MUST be in this list, even if endpoints are not reachable or host names are not resolvable for outside the service network. |
+| endpoints | array of [Endpoint](#endpoint-object) objects | The network endpoints that the Application uses to connect to the Service Instance. All Service Instance endpoints that are relevant for the Application MUST be in this list, even if endpoints are not reachable or host names are not resolvable from outside the service network. |
 
 ##### Volume Mount Object
 
@@ -1486,7 +1486,7 @@ For success responses, the following fields are defined:
 | route_service_url | string | A URL to which the Platform MUST proxy requests for the address sent with `bind_resource.route` in the request body. `"requires":["route_forwarding"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
 | volume_mounts | array of [VolumeMount](#volume-mount-object) objects | An array of configuration for mounting volumes. `"requires":["volume_mount"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
 | parameters | object | Configuration parameters for the Service Binding. |
-| endpoints | array of [Endpoint](#endpoint-object) objects | The network endpoints that the Application uses to connect to the Service Instance. All Service Instance endpoints that relevant for the Application MUST be in this list, even if endpoints are not reachable or host names are not resolvable for outside the service network. |
+| endpoints | array of [Endpoint](#endpoint-object) objects | The network endpoints that the Application uses to connect to the Service Instance. All Service Instance endpoints that are relevant for the Application MUST be in this list, even if endpoints are not reachable or host names are not resolvable from outside the service network. |
 
 Service Brokers MAY choose to not return some or all parameters when a Service Binding is fetched - for example,
 if it contains sensitive information.

--- a/spec.md
+++ b/spec.md
@@ -1369,7 +1369,7 @@ For `200 OK` and `201 Created` response codes, the following fields are defined:
 | syslog_drain_url | string | A URL to which logs MUST be streamed. `"requires":["syslog_drain"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
 | route_service_url | string | A URL to which the Platform MUST proxy requests for the address sent with `bind_resource.route` in the request body. `"requires":["route_forwarding"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
 | volume_mounts | array of [VolumeMount](#volume-mount-object) objects | An array of configuration for remote storage devices to be mounted into an application container filesystem. `"requires":["volume_mount"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
-| endpoints | array of [Endpoint](#endpoint-object) objects | The network endpoints that the Application uses to connect to the Service Instance. All Service Instance endpoints that are relevant for the Application MUST be in this list, even if endpoints are not reachable or host names are not resolvable from outside the service network. |
+| endpoints | array of [Endpoint](#endpoint-object) objects | The network endpoints that the Application uses to connect to the Service Instance. If present, all Service Instance endpoints that are relevant for the Application MUST be in this list, even if endpoints are not reachable or host names are not resolvable from outside the service network. |
 
 ##### Volume Mount Object
 
@@ -1486,7 +1486,7 @@ For success responses, the following fields are defined:
 | route_service_url | string | A URL to which the Platform MUST proxy requests for the address sent with `bind_resource.route` in the request body. `"requires":["route_forwarding"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
 | volume_mounts | array of [VolumeMount](#volume-mount-object) objects | An array of configuration for mounting volumes. `"requires":["volume_mount"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
 | parameters | object | Configuration parameters for the Service Binding. |
-| endpoints | array of [Endpoint](#endpoint-object) objects | The network endpoints that the Application uses to connect to the Service Instance. All Service Instance endpoints that are relevant for the Application MUST be in this list, even if endpoints are not reachable or host names are not resolvable from outside the service network. |
+| endpoints | array of [Endpoint](#endpoint-object) objects | The network endpoints that the Application uses to connect to the Service Instance. If present, all Service Instance endpoints that are relevant for the Application MUST be in this list, even if endpoints are not reachable or host names are not resolvable from outside the service network. |
 
 Service Brokers MAY choose to not return some or all parameters when a Service Binding is fetched - for example,
 if it contains sensitive information.

--- a/spec.md
+++ b/spec.md
@@ -1198,6 +1198,14 @@ Service Binding](#fetching-a-service-binding) endpoint. However, in order for
 the Platform to successfully use the Service Binding, the information MUST be
 returned at least once.
 
+In some cases, the creation of a Service Binding has to be accompanied by
+additional network configuration. This could be the configuration of a firewall
+or a load balancer or it could be the setup of a network tunnel or a VPN
+connection.
+To enable the Platform or another central component to do this in a service
+agnostic way, the Service Broker SHOULD provide the endpoints that the
+Application uses to connect to the service alongside the binding credentials.
+
 ### Types of Binding
 
 #### Credentials

--- a/spec.md
+++ b/spec.md
@@ -1202,9 +1202,9 @@ In some cases, the creation of a Service Binding has to be accompanied by
 additional network configuration. This could be the configuration of a firewall
 or a load balancer or it could be the setup of a network tunnel or a VPN
 connection.
-To enable the Platform or another central component to do this in a service
-agnostic way, the Service Broker SHOULD provide the endpoints that the
-Application uses to connect to the service alongside the binding credentials.
+To enable the Platform to do this in a service agnostic way, the Service Broker
+SHOULD provide the endpoints that the Application uses to connect to the service
+alongside the binding credentials.
 
 ### Types of Binding
 

--- a/spec.md
+++ b/spec.md
@@ -1369,7 +1369,7 @@ For `200 OK` and `201 Created` response codes, the following fields are defined:
 | syslog_drain_url | string | A URL to which logs MUST be streamed. `"requires":["syslog_drain"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
 | route_service_url | string | A URL to which the Platform MUST proxy requests for the address sent with `bind_resource.route` in the request body. `"requires":["route_forwarding"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
 | volume_mounts | array of [VolumeMount](#volume-mount-object) objects | An array of configuration for remote storage devices to be mounted into an application container filesystem. `"requires":["volume_mount"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
-| endpoints | array of [Endpoint](#endpoint-object) objects | The network endpoints that the Application uses to connect to the Service Instance. The endpoints need not to be reachable and the host names need not to resolvable from outside the service network. |
+| endpoints | array of [Endpoint](#endpoint-object) objects | The network endpoints that the Application uses to connect to the Service Instance. All Service Instance endpoints that relevant for the Application MUST be in this list, even if endpoints are not reachable or host names are not resolvable for outside the service network. |
 
 ##### Volume Mount Object
 
@@ -1486,7 +1486,7 @@ For success responses, the following fields are defined:
 | route_service_url | string | A URL to which the Platform MUST proxy requests for the address sent with `bind_resource.route` in the request body. `"requires":["route_forwarding"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
 | volume_mounts | array of [VolumeMount](#volume-mount-object) objects | An array of configuration for mounting volumes. `"requires":["volume_mount"]` MUST be declared in the [Catalog](#catalog-management) endpoint or the Platform can consider the response invalid. |
 | parameters | object | Configuration parameters for the Service Binding. |
-| endpoints | array of [Endpoint](#endpoint-object) objects | The network endpoints that the Application uses to connect to the Service Instance. The endpoints need not to be reachable and the host names need not to resolvable from outside the service network. |
+| endpoints | array of [Endpoint](#endpoint-object) objects | The network endpoints that the Application uses to connect to the Service Instance. All Service Instance endpoints that relevant for the Application MUST be in this list, even if endpoints are not reachable or host names are not resolvable for outside the service network. |
 
 Service Brokers MAY choose to not return some or all parameters when a Service Binding is fetched - for example,
 if it contains sensitive information.

--- a/spec.md
+++ b/spec.md
@@ -1209,7 +1209,7 @@ Service Bindings for the Service Instance.
 
 Service Brokers SHOULD also provide all network hosts and ports that the
 Application uses to connect to the Service Instance via this Service Binding.
-This data allows the Platform to adjust network configurations, if necessary. 
+This data allows the Platform to adjust network configurations, if necessary.
 
 #### Log Drain
 


### PR DESCRIPTION
I'm splitting the network metadata PR (#586) into multiple pieces to simplify the discussion.
This is part 1 - binding endpoint.

This PR defines how brokers can provide the network endpoints of a service instance to the platform. The endpoint data is sent along with the binding credentials and can be used by the platform (or other intermediate components) to configure network components.