### PR TITLE
Allow context to be updated and add org name, space name and instance name

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -154,6 +154,11 @@ Note that when both the originating identity HTTP Header and the Context
 object appear in the same message the `platform` value MUST be the same
 for both.
 
+To enable support for Platforms to send updated contextual data for Service
+Instances, a Service Broker MUST declare support by including
+`"allow_context_updates": true` in its
+[catalog endpoint](spec.md#catalog-management).
+
 ### Cloud Foundry Context Object
 
 *`platform` Property Value*: `cloudfoundry`
@@ -175,6 +180,21 @@ deployment:
   "organization_guid": "1113aa0-124e-4af2-1526-6bfacf61b111"
   ```
 
+- `organization_name`
+
+  Version: 2.15
+
+  The name of the organization that a Service Instance is associated with.
+  Note that the name of an organization in Cloud Foundry MAY be changed.
+  This property MUST be a non-empty string serialized as follows:
+  ```
+  "organization_name": "organization-name-here"
+  ```
+  For example:
+  ```
+  "organization_name": "system"
+  ```
+
 - `space_guid`
 
   Version: 2.11
@@ -189,14 +209,44 @@ deployment:
   "space_guid": "aaaa1234-da91-4f12-8ffa-b51d0336aaaa"
   ```
 
+- `space_name`
+
+  Version: 2.15
+
+  The name of the space that a Service Instance is associated with.
+  Note that the name of a space in Cloud Foundry MAY be changed.
+  This property MUST be a non-empty string serialized as follows:
+  ```
+  "space_name": "space-name-here"
+  ```
+  For example:
+  ```
+  "space_name": "development"
+  ```
+
+- `instance_name`
+
+  Version: 2.15
+
+  The name of the Service Instance.
+  Note that the name of a Service Instance in Cloud Foundry MAY be changed.
+  This property MUST be a non-empty string serialized as follows:
+  ```
+  "instance_name": "instance-name-here"
+  ```
+  For example:
+  ```
+  "instance_name": "my-db"
+  ```
+
 The following table specifies which properties will appear in each API.
 All properties specified are REQUIRED unless otherwise noted.
 
 | Request API | Properties |
 | --- | --- |
-| `PUT /v2/service_instances/:instance_id` | `organization_guid`, `space_guid` |
-| `PATCH /v2/service_instances/:instance_id` | `organization_guid`, `space_guid` |
-| `PUT /v2/service_instances/:instance_id/service_bindings/:binding_id` | `organization_guid`, `space_guid` |
+| `PUT /v2/service_instances/:instance_id` | `organization_guid`, `organization_name`, `space_guid`, `space_name`, `instance_name` |
+| `PATCH /v2/service_instances/:instance_id` | `organization_guid`, `organization_name`, `space_guid`, `space_name`, `instance_name` |
+| `PUT /v2/service_instances/:instance_id/service_bindings/:binding_id` | `organization_guid`, `organization_guid`, `space_guid`, `space_name` |
 
 The following example shows a `context` object that might appear as part of a
 Cloud Foundry API call:
@@ -204,7 +254,10 @@ Cloud Foundry API call:
   "context": {
     "platform": "cloudfoundry",
     "organization_guid": "1113aa0-124e-4af2-1526-6bfacf61b111",
-    "space_guid": "aaaa1234-da91-4f12-8ffa-b51d0336aaaa"
+    "organization_name": "system",
+    "space_guid": "aaaa1234-da91-4f12-8ffa-b51d0336aaaa",
+    "space_name": "development",
+    "instance_name": "my-db"
   }
   ```
 

--- a/spec.md
+++ b/spec.md
@@ -450,6 +450,7 @@ It is therefore RECOMMENDED that implementations avoid such strings.
 | bindable* | boolean | Specifies whether Service Instances of the service can be bound to applications. This specifies the default for all Service Plans of this Service Offering. Service Plans can override this field (see [Service Plan Object](#service-plan-object)). |
 | instances_retrievable | boolean | Specifies whether the [Fetching a Service Instance](#fetching-a-service-instance) endpoint is supported for all Service Plans. |
 | bindings_retrievable | boolean | Specifies whether the [Fetching a Service Binding](#fetching-a-service-binding) endpoint is supported for all Service Plans. |
+| allow_context_updates | boolean | Specifies whether a Service Instance supports [Update](#updating-a-service-instance) requests when contextual data for the Service Instance in the Platform changes. |
 | metadata | object | An opaque object of metadata for a Service Offering. It is expected that Platforms will treat this as a blob. Note that there are [conventions](profile.md#service-metadata) in existing Service Brokers and Platforms for fields that aid in the display of catalog data. |
 | dashboard_client | [DashboardClient](profile.md#dashboard-client-object) | A Cloud Foundry extension described in [Catalog Extensions](profile.md#catalog-extensions). Contains the data necessary to activate the Dashboard SSO feature for this service. |
 | plan_updateable | boolean | Whether the Service Offering supports upgrade/downgrade for Service Plans by default. Service Plans can override this field (see [Service Plan](#service-plan-object)). Please note that the misspelling of the attribute `plan_updatable` as `plan_updateable` was done by mistake. We have opted to keep that misspelling instead of fixing it and thus breaking backward compatibility. Defaults to false. |
@@ -527,6 +528,7 @@ schema being used.
     "bindable": true,
     "instances_retrievable": true,
     "bindings_retrievable": true,
+    "allow_context_updates": true,
     "metadata": {
       "provider": {
         "name": "The name"
@@ -897,7 +899,7 @@ Service Broker will use it to correlate the resource it creates.
 | --- | --- | --- |
 | service_id* | string | MUST be the ID of a Service Offering from the catalog for this Service Broker. |
 | plan_id* | string | MUST be the ID of a Service Plan from the Service Offering that has been requested. |
-| context | object | Platform specific contextual information under which the Service Instance is to be provisioned. Although most Service Brokers will not use this field, it could be helpful in determining data placement or applying custom business rules. `context` will replace `organization_guid` and `space_guid` in future versions of the specification - in the interim both SHOULD be used to ensure interoperability with old and new implementations. |
+| context | object | Contextual data for the Service Instance. `context` will replace `organization_guid` and `space_guid` in future versions of the specification - in the interim both SHOULD be used to ensure interoperability with old and new implementations. |
 | organization_guid* | string | Deprecated in favor of `context`. The Platform GUID for the organization under which the Service Instance is to be provisioned. Although most Service Brokers will not use this field, it might be helpful for executing operations on a user's behalf. MUST be a non-empty string. |
 | space_guid* | string | Deprecated in favor of `context`. The identifier for the project space within the Platform organization. Although most Service Brokers will not use this field, it might be helpful for executing operations on a user's behalf. MUST be a non-empty string. |
 | parameters | object | Configuration parameters for the Service Instance. Service Brokers SHOULD ensure that the client has provided valid configuration parameters and values for the operation. |
@@ -1031,11 +1033,18 @@ if it contains sensitive information.
 
 ## Updating a Service Instance
 
-By implementing this endpoint, Service Broker authors can enable users to
-modify two attributes of an existing Service Instance: the Service Plan and
-parameters. By changing the Service Plan, users can upgrade or downgrade their
-Service Instance to other Service Plans. By modifying parameters, users can change
-configuration options that are specific to a Service Offering or Service Plan.
+By implementing this endpoint, Service Broker authors can:
+* Enable users to modify the Service Plan of a Service Instance. By changing the
+  Service Plan, users can upgrade or downgrade their Service Instance to other
+  plans.
+* Enable users to modify the parameters of a Service Instance. By modifying
+  parameters, users can change configuration options that are specific to a
+  Service or Service Plan.
+* Enable Platforms to update contextual data of a Service Instance. To enable
+  support for Platforms to send updated contextual data for Service Instances, a
+  Service Broker MUST declare support by including
+  `"allow_context_updates": true` in its
+  [catalog endpoint](#catalog-management).
 
 To enable support for the update of the Service Plan, a Service Broker MUST declare
 support per Service Offering by including `"plan_updateable": true` in either the
@@ -1070,7 +1079,7 @@ error message in response.
 
 | Request Field | Type | Description |
 | --- | --- | --- |
-| context | object | Contextual data under which the Service Instance is created. |
+| context | object | Contextual data for the Service Instance. |
 | service_id* | string | MUST be the ID of a Service Offering from the catalog for this Service Broker. |
 | plan_id | string | If present, MUST be the ID of a Service Plan from the Service Offering that has been requested. If this field is not present in the request message, then the Service Broker MUST NOT change the Service Plan of the Service Instance as a result of this request. |
 | parameters | object | Configuration parameters for the Service Instance. Service Brokers SHOULD ensure that the client has provided valid configuration parameters and values for the operation. See "Note" below. |
@@ -1084,8 +1093,8 @@ error message in response.
 | --- | --- | --- |
 | service_id | string | Deprecated; determined to be unnecessary as the value is immutable. If present, it MUST be the ID of the Service Offering for the Service Instance. |
 | plan_id | string | If present, it MUST be the ID of the Service Plan prior to the update. |
-| organization_id | string | Deprecated as it was redundant information. Organization for the Service Instance MUST be provided by Platforms in the top-level field `context`. If present, it MUST be the ID of the organization specified for the Service Instance. |
-| space_id | string | Deprecated as it was redundant information. Space for the Service Instance MUST be provided by Platforms in the top-level field `context`. If present, it MUST be the ID of the space specified for the Service Instance. |
+| organization_id | string | Deprecated as it was redundant information. The organization ID for the Service Instance MUST be provided by Platforms in the top-level field `context`. If present, it MUST be the ID of the organization specified for the Service Instance. |
+| space_id | string | Deprecated as it was redundant information. The space ID for the Service Instance MUST be provided by Platforms in the top-level field `context`. If present, it MUST be the ID of the space specified for the Service Instance. |
 
 Note: The `parameters` specified are expected to be the values specified
 by an end-user. Whether the user chooses to include the complete set of
@@ -1262,7 +1271,7 @@ it to correlate the resource it creates.
 
 | Request Field | Type | Description |
 | --- | --- | --- |
-| context | object | Contextual data under which the Service Binding is created. |
+| context | object | Contextual data for the Service Binding. |
 | service_id* | string | MUST be the ID of the Service Offering that is being used. |
 | plan_id* | string | MUST be the ID of the Servie Plan from the service that is being used. |
 | app_guid | string | Deprecated in favor of `bind_resource.app_guid`. GUID of an application associated with the Service Binding to be created. If present, MUST be a non-empty string. |


### PR DESCRIPTION
PRs #620, #544 and #626 were all dealing with the same problem:
**It is useful for Service Brokers to understand Platform-side information for Service Instances**.

This was proving difficult, especially for the name of the service instance, and the org/space names in CF, because Platforms may allow this information to be changed at any time.

#620 considered adding a new `platform_metadata` object, but this looked very similar to the `context` object that already exists.
#544 considered adding a top-level `name` field to a Service Instance.
#626 is now included as part of this PR, and added `organization_name` and `space_name` to `context`, but with no way for Platforms to signal to Service Brokers if any of those values change

This PR therefore allows for the following:
* Service Broker authors can _opt-in_ to receive update service instance requests when contextual information in a Platform changes (i.e. the name of the service instance) by specifying `"allow_context_updates": true` in its catalog
* Platforms can send a `PATCH /v2/service_instances/:guid` request to Service Brokers that opt-in to this, sending updated Platform-side contextual information
* The `context` object for Cloud Foundry now includes `instance_name`, `organization_name` and `space_name`