### PR TITLE
Clarify the use of `allow_context_updates`

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -154,9 +154,9 @@ Note that when both the originating identity HTTP Header and the Context
 object appear in the same message the `platform` value MUST be the same
 for both.
 
-To enable support for Platforms to send updated contextual data for Service
-Instances, a Service Broker MUST declare support by including
-`"allow_context_updates": true` in its
+To enable support for Platforms to send an update request for a Service Instance
+containing only contextual data, a Service Broker MUST declare support by
+including `"allow_context_updates": true` in its
 [catalog endpoint](spec.md#catalog-management).
 
 ### Cloud Foundry Context Object

--- a/spec.md
+++ b/spec.md
@@ -1050,10 +1050,14 @@ By implementing this endpoint, Service Broker authors can:
 * Enable users to modify the parameters of a Service Instance. By modifying
   parameters, users can change configuration options that are specific to a
   Service or Service Plan.
-* Enable Platforms to update contextual data of a Service Instance. To enable
-  support for Platforms to send updated contextual data for Service Instances, a
-  Service Broker MUST declare support by including
-  `"allow_context_updates": true` in its
+* Enable Platforms to send an update request for a Service Instance containing
+  only contextual data (no changes to the Service Plan or parameters). This MAY
+  be used by Platforms to let Service Brokers know when contextual information
+  for a Service Instance has changed (i.e. `instance_name` in the
+  [Cloud Foundry Context Object](profile.md#cloud-foundry-context-object). To
+  enable support for Platforms to send an update request for a Service Instance
+  containing only contextual data, a Service Broker MUST declare support by
+  including `"allow_context_updates": true` in its
   [catalog endpoint](#catalog-management).
 
 To enable support for the update of the Service Plan, a Service Broker MUST declare


### PR DESCRIPTION
When #633 was merged, a new update workflow was added to the spec, allowing platforms to send a PATCH request to service brokers when only contextual information (like the name of the service instance in the platform) had changed. However, the text used to describe this made it sound like PATCH requests containing plan/parameter changes should not receive the `context` object unless `allow_context_updates` was set in the broker's catalog.

This PR aims to clarify what we really wanted to change in #633.