### PR TITLE
Add 'description' field to the 'maintenance_info.'

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -619,6 +619,8 @@ components:
           type: string
         metadata:
           $ref: '#/components/schemas/Metadata'
+        maintenance_info:
+          $ref: '#/components/schemas/MaintenanceInfo'
         free:
           type: boolean
           default: true
@@ -886,6 +888,16 @@ components:
     Metadata:
       description: "See [Service Metadata Conventions](https://github.com/openservicebrokerapi/servicebroker/blob/master/profile.md#service-metadata) for more details."
       type: object
+
+    MaintenanceInfo:
+      type: object
+      required:
+        - version
+      properties:
+        version:
+          type: string
+        description:
+          type: string
 
     Object:
       type: object

--- a/spec.md
+++ b/spec.md
@@ -547,7 +547,8 @@ schema being used.
 
 | Response Field | Type | Description |
 | --- | --- | --- |
-| version | string | This MUST be a string conforming to a semantic version. The Platform MAY use this field to determine whether an update is available for a Service Instance. |
+| version | string | This MUST be a string conforming to a semantic version. The Platform MAY use this field to determine whether a maintenance update is available for a Service Instance. |
+| description | string | This SHOULD be a string describing the impact of the maintenance update, for example, important version changes, configuration changes, default value changes, etc. The Platform MAY present this information to the user before they trigger the maintenance update. |
 
 ```
 {
@@ -644,6 +645,7 @@ schema being used.
       },
       "maintenance_info": {
         "version": "2.1.1+abcdef",
+        "description": "OS image update.\nExpect downtime."
       }
     }, {
       "name": "fake-plan-2",

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -748,6 +748,8 @@ definitions:
     properties:
       version:
         type: string
+      description:
+        type: string
   Context:
     description: >-
       See [Context


### PR DESCRIPTION
This tackles the `There SHOULD be some indication of the impact of an update`
part of #641.

This is not necessarily about a description string containing versions changes
only, this may contain details about configuration changes, the default value
changes, etc.

The main use case for `maintenance_info` and `description` field is for the
plans that need maintenance done to them every 2-4 weeks or so, thus creating a
new plan every time is not an option.

[#165560405](https://www.pivotaltracker.com/story/show/165560405)

**What is the problem this PR solves?**
A description of what the problem is, or a link to an issue which this is related to.

**Checklist:**
- [x] The [swagger.yaml](swagger.yaml) doc has been updated with any required changes
- [x] The [openapi.yaml](openapi.yaml) doc has been updated with any required changes
