### PR TITLE
Add OpenAPI and Swagger validation to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@
 language: bash
 
 services:
+  - docker
 
 before_install:
-  
+
 script:
   tools/verify-all.sh

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -282,7 +282,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/LastOperationResource'
           headers:
-            - $ref: '#/components/parameters/RetryAfter'
+            Retry-After:
+              description: Indicates when to retry the request
+              required: false
+              schema:
+                type: string
         '400':
           description: Bad Request
           content:
@@ -339,7 +343,11 @@ paths:
               schema:
                 $ref: '#/components/schemas/LastOperationResource'
           headers:
-            - $ref: '#/components/parameters/RetryAfter'
+            Retry-After:
+              description: Indicates when to retry the request
+              required: false
+              schema:
+               type: string
         '400':
           description: Bad Request
           content:
@@ -534,14 +542,6 @@ components:
       name: X-Broker-API-Originating-Identity
       in: header
       description: identity of the user that initiated the request from the Platform
-      schema:
-        type: string
-
-    RetryAfter:
-      name: Retry-After
-      in: header
-      description: Indicates when to retry the request
-      require: false
       schema:
         type: string
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -56,7 +56,11 @@ paths:
       - $ref: '#/parameters/APIVersion'
       - $ref: '#/parameters/OriginatingIdentity'
       - $ref: '#/parameters/RequestIdentity'
-      - $ref: '#/parameters/instance_id'
+      - name: instance_id
+        in: path
+        description: instance id of instance to provision
+        required: true
+        type: string
     put:
       summary: provision a service instance
       tags:
@@ -180,7 +184,11 @@ paths:
       - $ref: '#/parameters/APIVersion'
       - $ref: '#/parameters/OriginatingIdentity'
       - $ref: '#/parameters/RequestIdentity'
-      - $ref: '#/parameters/instance_id'
+      - name: instance_id
+        in: path
+        description: instance id of instance to provision
+        required: true
+        type: string
     get:
       summary: last requested operation state for service instance
       tags:
@@ -223,8 +231,16 @@ paths:
       - $ref: '#/parameters/APIVersion'
       - $ref: '#/parameters/OriginatingIdentity'
       - $ref: '#/parameters/RequestIdentity'
-      - $ref: '#/parameters/instance_id'
-      - $ref: '#/parameters/binding_id'
+      - name: instance_id
+        in: path
+        description: instance id of instance to provision
+        required: true
+        type: string
+      - name: binding_id
+        in: path
+        description: binding id of binding to create
+        required: true
+        type: string
     get:
       summary: last requested operation state for service binding
       tags:
@@ -267,8 +283,16 @@ paths:
       - $ref: '#/parameters/APIVersion'
       - $ref: '#/parameters/OriginatingIdentity'
       - $ref: '#/parameters/RequestIdentity'
-      - $ref: '#/parameters/instance_id'
-      - $ref: '#/parameters/binding_id'
+      - name: instance_id
+        in: path
+        description: instance id of instance to provision
+        required: true
+        type: string
+      - name: binding_id
+        in: path
+        description: binding id of binding to create
+        required: true
+        type: string
     put:
       summary: generation of a service binding
       tags:
@@ -375,12 +399,6 @@ parameters:
     in: header
     description: idenity of the request from the Platform
     type: string
-  instance_id:
-    name: instance_id
-    in: path
-    description: instance id of instance to provision
-    required: true
-    type: string
   accepts_incomplete:
     name: accepts_incomplete
     in: query
@@ -396,12 +414,6 @@ parameters:
     name: plan_id
     in: query
     description: id of the plan associated with the instance being deleted
-    required: true
-    type: string
-  binding_id:
-    name: binding_id
-    in: path
-    description: binding id of binding to create
     required: true
     type: string
 


### PR DESCRIPTION
**What is the problem this PR solves?**
Fixes issue #664 by adding validation of Swagger and OpenAPI in TravisCI

This is done using a validator from DockerHub, and it does therefore add an external dependency to CI.

Note that due to errors in the Swagger and OpenAPI validation covered by #662, the Travis CI build fails with this change. Here is an example: https://travis-ci.com/blgm/servicebroker/builds/111944021

**Checklist:**
- ~~[ ] The [swagger.yaml](swagger.yaml) doc has been updated with any required changes~~ Not applicable
- ~~[ ] The [openapi.yaml](openapi.yaml) doc has been updated with any required changes~~ Not applicable
