### PR TITLE
Clarify version of semantic versioning of maintenance_info.version

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -547,7 +547,7 @@ schema being used.
 
 | Response Field | Type | Description |
 | --- | --- | --- |
-| version | string | This MUST be a string conforming to a semantic version. The Platform MAY use this field to determine whether an update is available for a Service Instance. |
+| version | string | This MUST be a string conforming to a [semantic version 2.0](https://semver.org/spec/v2.0.0.html). The Platform MAY use this field to determine whether an update is available for a Service Instance. |
 
 ```
 {


### PR DESCRIPTION
**What is the problem this PR solves?**

So that when semver 2.1 or 3.0 gets released, it would be clear which
version should Brokers and Platforms implement, and will allow OSBAPI
group to update the referenced version in one of the next OSBAPI
releases when it makes sense to do so. It gives more control over what
that version field even means.

**Checklist:**
- [x] The [swagger.yaml](swagger.yaml) doc has been updated with any required changes (not applicable)
- [x] The [openapi.yaml](openapi.yaml) doc has been updated with any required changes (not applicable)
