### PR TITLE
Rename ServiceInstanceProvision to ServiceInstance

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -73,13 +73,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ServiceInstanceProvision'
+                $ref: '#/components/schemas/ServiceInstanceProvisionResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ServiceInstanceProvision'
+                $ref: '#/components/schemas/ServiceInstanceProvisionResponse'
         '202':
           description: Accepted
           content:
@@ -400,13 +400,13 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ServiceBinding'
+                $ref: '#/components/schemas/ServiceBindingResponse'
         '201':
           description: Created
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ServiceBinding'
+                $ref: '#/components/schemas/ServiceBindingResponse'
         '202':
           description: Accepted
           content:
@@ -695,7 +695,7 @@ components:
         parameters:
           $ref: '#/components/schemas/Object'
 
-    ServiceInstanceProvision:
+    ServiceInstanceProvisionResponse:
       type: object
       properties:
         dashboard_url:
@@ -808,7 +808,7 @@ components:
         route:
           type: string
 
-    ServiceBinding:
+    ServiceBindingResponse:
       type: object
       properties:
         credentials:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -78,11 +78,11 @@ paths:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/ServiceInstanceProvision'
+            $ref: '#/definitions/ServiceInstanceProvisionResponse'
         '201':
           description: Created
           schema:
-            $ref: '#/definitions/ServiceInstanceProvision'
+            $ref: '#/definitions/ServiceInstanceProvisionResponse'
         '202':
           description: Accepted
           schema:
@@ -310,11 +310,11 @@ paths:
         '200':
           description: OK
           schema:
-            $ref: '#/definitions/ServiceBinding'
+            $ref: '#/definitions/ServiceBindingResponse'
         '201':
           description: Created
           schema:
-            $ref: '#/definitions/ServiceBinding'
+            $ref: '#/definitions/ServiceBindingResponse'
         '202':
           description: Accepted
           schema:
@@ -605,7 +605,7 @@ definitions:
         $ref: '#/definitions/Object'
       maintenance_info:
         $ref: '#/definitions/MaintenanceInfo'
-  ServiceInstanceProvision:
+  ServiceInstanceProvisionResponse:
     type: object
     properties:
       dashboard_url:
@@ -709,7 +709,7 @@ definitions:
         type: string
       route:
         type: string
-  ServiceBinding:
+  ServiceBindingResponse:
     type: object
     properties:
       credentials:


### PR DESCRIPTION
**What is the problem this PR solves?**
When I use the [OpenAPITools](https://github.com/OpenAPITools/openapi-generator) tool to auto-generate Golang code from swagger.yaml (and openapi.yaml), it seems that the `ServiceInstanceProvision` defined is conflict with the generated `ServiceInstanceProvision` method. So this PR is proposed to rename `ServiceInstanceProvision` to `ServiceInstanceProvisionResponse` so as to avoid the name confusion. Besides, to keep all name consistent, `ServiceBinding` field would also been renamed to `ServiceBindingResponse`.

**Checklist:**
- [x] The [swagger.yaml](swagger.yaml) doc has been updated with any required changes
- [x] The [openapi.yaml](openapi.yaml) doc has been updated with any required changes