### PR TITLE
Service Brokers SHOULD remember the state of an operation for a reasonable +amount of time

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -809,6 +809,10 @@ For asynchronous provision operations, if the response contains
 `"state": "failed"` then the Platform might need to perform
 [Orphan Mitigation](#orphan-mitigation).
 
+Service Brokers SHOULD NOT forget the state of an operation immediately after
+returning a `"succeeded"` or `"failed"` state in case the Platform needs to ask
+again.
+
 ## Polling Last Operation for Service Bindings
 
 When a broker returns status code `202 Accepted` for [Binding](#binding) or
@@ -889,6 +893,10 @@ timestamp.
 
 If the response contains `"state": "failed"`, then the Platform might need to
 perform [Orphan Mitigation](#orphan-mitigation).
+
+Service Brokers SHOULD NOT forget the state of an operation immediately after
+returning a `"succeeded"` or `"failed"` state in case the Platform needs to ask
+again.
 
 ## Polling Interval and Duration
 


### PR DESCRIPTION
**What is the problem this PR solves?**
Closes #359. Obviously, a _reasonable amount of time_ is up for debate. I'm not sure if this is a bad idea or not, especially for a specification!

**Checklist:**
- [x] The [swagger.yaml](swagger.yaml) doc has been updated with any required changes
- [x] The [openapi.yaml](openapi.yaml) doc has been updated with any required changes
