### PR TITLE
Add 4xx responses from spec to openapi.yaml and swagger.yaml

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -92,6 +92,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '409':
           description: Conflict
           content:
@@ -149,6 +155,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '422':
           description: Unprocessable entity
           content:
@@ -201,6 +213,12 @@ paths:
                 $ref: '#/components/schemas/AsyncOperation'
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
           content:
             application/json:
               schema:
@@ -303,6 +321,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '404':
           description: Not Found
           content:
@@ -366,6 +390,12 @@ paths:
                type: string
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
           content:
             application/json:
               schema:
@@ -441,6 +471,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '409':
           description: Conflict
           content:
@@ -505,6 +541,12 @@ paths:
                 $ref: '#/components/schemas/AsyncOperation'
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Unauthorized
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -303,6 +303,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '410':
           description: Gone
           content:
@@ -360,6 +366,12 @@ paths:
                type: string
         '400':
           description: Bad Request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Not Found
           content:
             application/json:
               schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -515,6 +515,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '422':
+          description: Unprocessable Entity
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
     get:
       summary: get a service binding
       tags:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -947,7 +947,7 @@ components:
         instance_usable:
           type: boolean
         update_repeatable:
-          type: boolean 
+          type: boolean
 
   securitySchemes:
     basicAuth:

--- a/spec.md
+++ b/spec.md
@@ -782,6 +782,7 @@ $ curl http://username:password@service-broker-url/v2/service_instances/:instanc
 | --- | --- |
 | 200 OK | MUST be returned upon successful processing of this request. The expected response body is below. |
 | 400 Bad Request | MUST be returned if the request is malformed or missing mandatory data. MAY be returned if the request contains invalid data, in which case the error response MAY include a helpful error message in the `description` field (see [Service Broker Errors](#service-broker-errors)). |
+| 404 Not Found | MUST be returned if the Service Instance being polled does not exist. |
 | 410 Gone | Appropriate only for asynchronous delete operations. The Platform MUST consider this response a success and forget about the resource. Returning this while the Platform is polling for create or update operations SHOULD be interpreted as an invalid response and the Platform SHOULD continue polling. |
 
 Responses with any other status code SHOULD be interpreted as an error or
@@ -870,6 +871,7 @@ $ curl http://username:password@broker-url/v2/service_instances/:instance_id/ser
 | --- | --- |
 | 200 OK | MUST be returned upon successful processing of this request. The expected response body is below. |
 | 400 Bad Request | MUST be returned if the request is malformed or missing mandatory data. MAY be returned if the request contains invalid data, in which case the error response MAY include a helpful error message in the `description` field (see [Service Broker Errors](#service-broker-errors)). |
+| 404 Not Found | MUST be returned if the Service Binding being polled does not exist. |
 | 410 Gone | Appropriate only for asynchronous delete operations. The Platform MUST consider this response a success and remove the resource from its database. Returning this while the Platform is polling for create operations SHOULD be interpreted as an invalid response and the Platform SHOULD continue polling. |
 
 Responses with any other status code SHOULD be interpreted as an error or

--- a/spec.md
+++ b/spec.md
@@ -399,9 +399,9 @@ likelihood of having compatibility with any Platform.
 
 Service Brokers and Platforms MAY support the
 [`ETag`](https://tools.ietf.org/html/rfc7232#section-2.3) and
-[`If-Modified-Since`](https://tools.ietf.org/html/rfc7232#section-3.3) 
+[`If-Modified-Since`](https://tools.ietf.org/html/rfc7232#section-3.3)
 HTTP headers to enable caching of the catalog.
-(See [RFC 7232](https://tools.ietf.org/html/rfc7232) for details.) 
+(See [RFC 7232](https://tools.ietf.org/html/rfc7232) for details.)
 
 The following sections describe catalog requests and responses in the Service
 Broker API.

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -689,7 +689,7 @@ definitions:
       instance_usable:
         type: boolean
       update_repeatable:
-        type: boolean 
+        type: boolean
   ServiceBindingResource:
     type: object
     properties:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -227,6 +227,8 @@ paths:
               type: string
         '400':
           $ref: '#/responses/ErrorBadRequest'
+        '404':
+          $ref: '#/responses/ErrorNotFound'
         '401':
           $ref: '#/responses/ErrorUnauthorized'
         '410':
@@ -279,6 +281,8 @@ paths:
               type: string
         '400':
           $ref: '#/responses/ErrorBadRequest'
+        '404':
+          $ref: '#/responses/ErrorNotFound'
         '401':
           $ref: '#/responses/ErrorUnauthorized'
         '410':


### PR DESCRIPTION
**What is the problem this PR solves?**
This Pull Request adds 404 and 422 as permitted responses to the `openapi.yaml` and `swagger.yaml` where contextually appropriate.

Specifically, it adds 422 as an acceptable response to unbinding requests in the `openapi.yaml`, as documented in the spec:
https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#unbinding
and as provided in the `swagger.yaml`:
https://github.com/openservicebrokerapi/servicebroker/blob/master/swagger.yaml#L371-L372

Furthermore, it adds 404 as an acceptable response to the `last_operation` requests on service instances and service bindings. While not explicitly documented in the spec, 404 is an acceptable response for the parent URIs in question:
`/v2/service_instances/:instance_id` => https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#response-4
`/v2/service_instances/:instance_id/service_bindings/:binding_id` => https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#response-7

Which suggests that these should also be permitted responses in the case of child responses.

Given that 9de42fd introduces a slight behavioral change in the API, I am happy to revert it if that is deemed appropriate.

Finally, it adds 401 Unauthorized as an acceptable response in the `openapi.yaml`. This is a permitted response per the spec and the `swagger.yaml`.

**Checklist:**
- [x] The [swagger.yaml](swagger.yaml) doc has been updated with any required changes
- [x] The [openapi.yaml](openapi.yaml) doc has been updated with any required changes
