### PR TITLE
Document existing CF credential_client_id bind ressource

### DIFF
--- a/profile.md
+++ b/profile.md
@@ -436,7 +436,7 @@ object in which Platforms MAY choose to add additional fields.
 
 ### Cloud Foundry Bind Resource Object
 
-The Cloud Foundry Bind Resource Object supports the Cloud Foundry [Service Binding](https://docs.cloudfoundry.org/devguide/services/application-binding.html) and the [Service Key](https://docs.cloudfoundry.org/devguide/services/service-keys.html) developer requests. The credentials returned by the Service Binding endpoints MAY be references to credentials stored in [CredHub](https://docs.cloudfoundry.org/credhub/index.html), the component designed for centralized credential management in Cloud Foundry. Service Brokers are then responsible for writing credentials into CredHub and granting read permissions to a bound application or a specified client. See more details into [Credhub documentation](https://github.com/cloudfoundry-incubator/credhub/blob/master/docs/secure-service-credentials.md#service-brokers). The provisioning of CredHub access for service brokers is performed out of band and is out of scope of this specification. 
+The Cloud Foundry Bind Resource Object supports the Cloud Foundry [Service Binding](https://docs.cloudfoundry.org/devguide/services/application-binding.html) and the [Service Key](https://docs.cloudfoundry.org/devguide/services/service-keys.html) developer requests. The credentials returned by the Service Binding endpoints MAY be references to credentials stored in [CredHub](https://docs.cloudfoundry.org/credhub/index.html), the component designed for centralized credential management in Cloud Foundry. Service Brokers are then responsible for writing credentials into CredHub and granting read permissions to a bound application or a specified client. See more details into [Credhub documentation](https://github.com/cloudfoundry-incubator/credhub/blob/master/docs/secure-service-credentials.md#service-brokers). The provisioning of CredHub access for Service Brokers is performed out of band and is out of scope of this specification.
 
 The following properties are defined for usage within a Cloud Foundry
 deployment:
@@ -473,8 +473,8 @@ deployment:
 
   Version: 2.16
   
-  When the Bind Resource Object is the result of a Cloud Foundry [service key](https://docs.cloudfoundry.org/devguide/services/service-keys.html) developer request, then the Cloud Cloundry CredHub client id is provided. This supports Service Brokers that MAY choose use to securely store Service Binding credentials, and return [credhub references](https://github.com/cloudfoundry-incubator/credhub/blob/master/docs/secure-service-credentials.md#service-brokers) Service Binding responses instead of plain credentials values. In this case, the provided client MUST be granted permission by the Service Broker to read the returned credentials reference.  
-  This OPTIONAL property holds a string with the client id that should be granted read permissions. If present, this property MUST be a non empty string as follows:
+  When the Bind Resource Object is the result of a Cloud Foundry [service key](https://docs.cloudfoundry.org/devguide/services/service-keys.html) developer request, then the Cloud Cloundry CredHub client id is provided. This supports Service Brokers that MAY choose use to securely store Service Binding credentials, and return [credhub references](https://github.com/cloudfoundry-incubator/credhub/blob/master/docs/secure-service-credentials.md#service-brokers) Service Binding responses instead of plain credentials values. In this case, the provided client MUST be granted permission by the Service Broker to read the returned credentials reference.
+  This OPTIONAL property holds a string with the client id that MUST be granted read permissions. If present, this property MUST be a non empty string as follows:
   
   ```
     "credential_client_id": "client_id-value-here"

--- a/profile.md
+++ b/profile.md
@@ -436,6 +436,8 @@ object in which Platforms MAY choose to add additional fields.
 
 ### Cloud Foundry Bind Resource Object
 
+The Cloud Foundry Bind Resource Object supports the Cloud Foundry [Service Binding](https://docs.cloudfoundry.org/devguide/services/application-binding.html) and the [Service Key](https://docs.cloudfoundry.org/devguide/services/service-keys.html) developer requests. The credentials returned by the Service Binding endpoints MAY be references to credentials stored in [CredHub](https://docs.cloudfoundry.org/credhub/index.html), the component designed for centralized credential management in Cloud Foundry. Service Brokers are then responsible for writing credentials into CredHub and granting read permissions to a bound application or a specified client. See more details into [Credhub documentation](https://github.com/cloudfoundry-incubator/credhub/blob/master/docs/secure-service-credentials.md#service-brokers). The provisioning of CredHub access for service brokers is performed out of band and is out of scope of this specification. 
+
 The following properties are defined for usage within a Cloud Foundry
 deployment:
 
@@ -471,8 +473,8 @@ deployment:
 
   Version: 2.16
   
-  The Cloud Cloundry credhub client id that Service Brokers can use to securely store Service Binding credentials, and returns [credhub references](https://github.com/cloudfoundry-incubator/credhub/blob/master/docs/secure-service-credentials.md#service-brokers) Service Binding responses instead of plain credentials values.
-  This OPTIONAL property holds a string with the client id to use. If present, this property MUST be a non empty string as follows:
+  When the Bind Resource Object is the result of a Cloud Foundry [service key](https://docs.cloudfoundry.org/devguide/services/service-keys.html) developer request, then the Cloud Cloundry CredHub client id is provided. This supports Service Brokers that MAY choose use to securely store Service Binding credentials, and return [credhub references](https://github.com/cloudfoundry-incubator/credhub/blob/master/docs/secure-service-credentials.md#service-brokers) Service Binding responses instead of plain credentials values. In this case, the provided client MUST be granted permission by the Service Broker to read the returned credentials reference.  
+  This OPTIONAL property holds a string with the client id that should be granted read permissions. If present, this property MUST be a non empty string as follows:
   
   ```
     "credential_client_id": "client_id-value-here"
@@ -483,11 +485,19 @@ deployment:
   ```
   
 The following example shows a `bind_resource` object that might appear as part
-of a Cloud Foundry API call:
+of a Cloud Foundry API call resulting from a Service Binding developer request:
   ```
   "bind_resource": {
     "app_guid": "5e76c9bf-d5e3-46bf-9877-6d8dddfc8a45",
     "space_guid": "15823972-c216-4ba5-9f3f-e75b0b891297"
+  }
+  ```
+
+The following example shows a `bind_resource` object that might appear as part
+of a Cloud Foundry API call resulting from a Service Key developer request:
+  ```
+  "bind_resource": {
+    "credential_client_id": "cc_service_key_client"
   }
   ```
 

--- a/profile.md
+++ b/profile.md
@@ -471,7 +471,7 @@ deployment:
 
   Version: 2.16
   
-  The Cloud Cloundry credhub client id that Service Brokers may use to securely store service binding credentials, and returns [credhub references](https://github.com/cloudfoundry-incubator/credhub/blob/master/docs/secure-service-credentials.md#service-brokers) Service Binding responses instead of plain credentials values.
+  The Cloud Cloundry credhub client id that Service Brokers can use to securely store Service Binding credentials, and returns [credhub references](https://github.com/cloudfoundry-incubator/credhub/blob/master/docs/secure-service-credentials.md#service-brokers) Service Binding responses instead of plain credentials values.
   This OPTIONAL property holds a string with the client id to use. If present, this property MUST be a non empty string as follows:
   
   ```

--- a/profile.md
+++ b/profile.md
@@ -471,7 +471,7 @@ deployment:
 
   Version: 2.16
   
-  The Cloud Cloundry credhub client id that service brokers may use to securely store service binding credentials, and returns [credhub references](https://github.com/cloudfoundry-incubator/credhub/blob/master/docs/secure-service-credentials.md#service-brokers) service binding responses instead of plain credentials values. 
+  The Cloud Cloundry credhub client id that Service Brokers may use to securely store service binding credentials, and returns [credhub references](https://github.com/cloudfoundry-incubator/credhub/blob/master/docs/secure-service-credentials.md#service-brokers) Service Binding responses instead of plain credentials values.
   This OPTIONAL property holds a string with the client id to use. If present, this property MUST be a non empty string as follows:
   
   ```

--- a/profile.md
+++ b/profile.md
@@ -467,9 +467,21 @@ deployment:
   "app_annotations": { "myprovider.com/send-alerts-to-email":"me@mycompany.com" }
   ```
 
+- `credential_client_id`
 
-
-
+  Version: 2.16
+  
+  The Cloud Cloundry credhub client id that service brokers may use to securely store service binding credentials, and returns [credhub references](https://github.com/cloudfoundry-incubator/credhub/blob/master/docs/secure-service-credentials.md#service-brokers) service binding responses instead of plain credentials values. 
+  This OPTIONAL property holds a string with the client id to use. If present, this property MUST be a non empty string as follows:
+  
+  ```
+    "credential_client_id": "client_id-value-here"
+  ```
+  For example:
+  ```
+    "credential_client_id": "cc_service_key_client"
+  ```
+  
 The following example shows a `bind_resource` object that might appear as part
 of a Cloud Foundry API call:
   ```


### PR DESCRIPTION
**What is the problem this PR solves?**

credential_client_id is provided by cloudfoundry cloudcontroller in the binding resource since late 2017. See background at https://www.pivotaltracker.com/n/projects/966314/stories/151111701

**Checklist:**
- [ ] The [swagger.yaml](swagger.yaml) doc has been updated with any required changes
  - Existing profile fields seems not described in the current [swagger.yml ServiceBindingResourceObject](https://github.com/openservicebrokerapi/servicebroker/blob/765742d26dfa24680d1a62f7c7736cf48f1e4036/swagger.yaml#L729-L735)
- [ ] The [openapi.yaml](openapi.yaml) doc has been updated with any required changes
   - Existing profile fields seems not described in the current [openapi.yaml ServiceBindingResource](https://github.com/openservicebrokerapi/servicebroker/blob/765742d26dfa24680d1a62f7c7736cf48f1e4036/openapi.yaml#L787-L808)
