### PR TITLE
Service Instances can be labelled with information defined by the Broker

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -720,6 +720,8 @@ components:
       properties:
         dashboard_url:
           type: string
+        metadata:
+          type: object
 
     ServiceInstanceAsyncOperation:
       type: object
@@ -728,6 +730,8 @@ components:
           type: string
         operation:
           type: string # could be a link object to last operation
+        metadata:
+          type: object
 
     ServiceInstanceUpdateRequest:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -721,7 +721,7 @@ components:
         dashboard_url:
           type: string
         metadata:
-          type: object
+          $ref: '#/components/schemas/ServiceInstanceMetadata'
 
     ServiceInstanceAsyncOperation:
       type: object
@@ -731,6 +731,12 @@ components:
         operation:
           type: string # could be a link object to last operation
         metadata:
+          $ref: '#/components/schemas/ServiceInstanceMetadata'
+
+    ServiceInstanceMetadata:
+      type: object
+      properties:
+        labels:
           type: object
 
     ServiceInstanceUpdateRequest:

--- a/spec.md
+++ b/spec.md
@@ -1030,7 +1030,7 @@ For success responses, the following fields are defined:
 }
 ```
 
-##### ServiceInstanceMetadata
+##### Service Instance Metadata
 
 | Response Field | Type | Description |
 | --- | --- | --- |

--- a/spec.md
+++ b/spec.md
@@ -1016,13 +1016,27 @@ For success responses, the following fields are defined:
 | --- | --- | --- |
 | dashboard_url | string | The URL of a web-based management user interface for the Service Instance; we refer to this as a service dashboard. The URL MUST contain enough information for the dashboard to identify the resource being accessed (`9189kdfsk0vfnku` in the example below). Note: a Service Broker that wishes to return `dashboard_url` for a Service Instance MUST return it with the initial response to the provision request, even if the service is provisioned asynchronously. If present, MUST be a string or null. |
 | operation | string | For asynchronous responses, Service Brokers MAY return an identifier representing the operation. The value of this field MUST be provided by the Platform with requests to the [Polling Last Operation for Service Instances](#polling-last-operation-for-service-instances) endpoint in a percent-encoded query parameter. If present, MAY be null, and MUST NOT contain more than 10,000 characters. |
-
+| metadata | [ServiceInstanceMetadata](#service-instance-metadata) object | An OPTIONAL object containing metadata about this Service Instance. |
 ```
 {
   "dashboard_url": "http://example-dashboard.example.com/9189kdfsk0vfnku",
-  "operation": "task_10"
+  "operation": "task_10",
+  "metadata": {
+    "labels": {
+      "key1" : "value1",
+      "key2" : "value2"
+    }
+  }
 }
 ```
+
+##### ServiceInstanceMetadata
+
+| Response Field | Type | Description |
+| --- | --- | --- |
+| labels | object | Labels are broker specified key value pairs that are attached to Service Instances. Labels are intended to be used to specify attributes of Service Instances that are meaningful and relevant to users, but do not directly imply behaviour changes by the Platform. Platforms that support labels MAY chose to update their view of the metadata to match this one. |
+
+Note: Platforms that support metadata labels should make sure the characters used in the key should adhere to what's supported by the Platform.
 
 ## Fetching a Service Instance
 

--- a/spec.md
+++ b/spec.md
@@ -1016,7 +1016,7 @@ For success responses, the following fields are defined:
 | --- | --- | --- |
 | dashboard_url | string | The URL of a web-based management user interface for the Service Instance; we refer to this as a service dashboard. The URL MUST contain enough information for the dashboard to identify the resource being accessed (`9189kdfsk0vfnku` in the example below). Note: a Service Broker that wishes to return `dashboard_url` for a Service Instance MUST return it with the initial response to the provision request, even if the service is provisioned asynchronously. If present, MUST be a string or null. |
 | operation | string | For asynchronous responses, Service Brokers MAY return an identifier representing the operation. The value of this field MUST be provided by the Platform with requests to the [Polling Last Operation for Service Instances](#polling-last-operation-for-service-instances) endpoint in a percent-encoded query parameter. If present, MAY be null, and MUST NOT contain more than 10,000 characters. |
-| metadata | [ServiceInstanceMetadata](#service-instance-metadata) object | An OPTIONAL object containing metadata about this Service Instance. |
+| metadata | [ServiceInstanceMetadata](#service-instance-metadata) object | An OPTIONAL object containing metadata for the Service Instance. |
 ```
 {
   "dashboard_url": "http://example-dashboard.example.com/9189kdfsk0vfnku",
@@ -1288,14 +1288,19 @@ For success responses, the following fields are defined:
 | --- | --- | --- |
 | dashboard_url | string | The updated URL of a web-based management user interface for the Service Instance; we refer to this as a service dashboard. The URL MUST contain enough information for the dashboard to identify the resource being accessed (`0129d920a083838` in the example below). Note: a Service Broker that wishes to return `dashboard_url` for a Service Instance MUST return it with the initial response to the update request, even if the Service Instance is being updated asynchronously. If not present or null, the Platform MUST retain the previous value of the `dashboard_url`. |
 | operation | string | For asynchronous responses, Service Brokers MAY return an identifier representing the operation. The value of this field MUST be provided by the Platform with requests to the [Polling Last Operation for Service Instances](#polling-last-operation-for-service-instances) endpoint in a percent-encoded query parameter. If present, MUST be a non-empty string. |
-
+| metadata | [ServiceInstanceMetadata](#service-instance-metadata) object | An OPTIONAL object containing metadata for the Service Instance. |
 ```
 {
-  "dashboard_url": "http://example-dashboard.example.com/0129d920a083838",
-  "operation": "task_10"
+  "dashboard_url": "http://example-dashboard.example.com/9189kdfsk0vfnku",
+  "operation": "task_10",
+  "metadata": {
+    "labels": {
+      "key1" : "value1",
+      "key2" : "value2"
+    }
+  }
 }
 ```
-
 
 ## Binding
 

--- a/spec.md
+++ b/spec.md
@@ -1089,7 +1089,6 @@ For success responses, the following fields are defined:
 | plan_id | string | The ID of the Service Plan from the catalog that is associated with the Service Instance. |
 | dashboard_url | string | The URL of a web-based management user interface for the Service Instance; we refer to this as a service dashboard. The URL MUST contain enough information for the dashboard to identify the resource being accessed (`9189kdfsk0vfnku` in the example below). Note: a Service Broker that wishes to return `dashboard_url` for a Service Instance MUST return it with the initial response to the provision request, even if the service is provisioned asynchronously. |
 | parameters | object | Configuration parameters for the Service Instance. |
-| metadata | [ServiceInstanceMetadata](#service-instance-metadata) object | An OPTIONAL object containing metadata about this Service Instance. |
 
 Service Brokers MAY choose to not return some or all parameters when a Service Instance is fetched - for example,
 if it contains sensitive information.
@@ -1099,12 +1098,6 @@ if it contains sensitive information.
   "dashboard_url": "http://example-dashboard.example.com/9189kdfsk0vfnku",
   "parameters": {
     "billing-account": "abcde12345"
-  },
-  "metadata": {
-    "labels": {
-      "key1" : "value1",
-      "key2" : "value2"
-    }
   }
 }
 ```

--- a/spec.md
+++ b/spec.md
@@ -1034,7 +1034,7 @@ For success responses, the following fields are defined:
 
 | Response Field | Type | Description |
 | --- | --- | --- |
-| labels | object | Labels are broker specified key-value pairs specifying attributes of Service Instances that are meaningful and relevant to Platform users, but do not directly imply behaviour changes by the Platform. Platforms that support metadata labels MAY chose to update the those, and if they do, they SHOULD replace all existing metadata labels with the labels received during provision or update. The Platform SHOULD ignore labels that do not adhere to the Platforms syntax. |
+| labels | object | Labels are broker specified key-value pairs specifying attributes of Service Instances that are meaningful and relevant to Platform users, but do not directly imply behaviour changes by the Platform. Platforms that support metadata labels MAY chose to update those, and if they do, they SHOULD replace all existing metadata labels with the labels received during provision or update. The Platform SHOULD ignore labels that do not adhere to the Platforms syntax. |
 
 ## Fetching a Service Instance
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -628,6 +628,8 @@ definitions:
     properties:
       dashboard_url:
         type: string
+      metadata:
+        $ref: '#/definitions/ServiceInstanceMetadata'
   ServiceInstanceAsyncOperation:
     type: object
     properties:
@@ -635,6 +637,8 @@ definitions:
         type: string
       operation:
         type: string
+      metadata:
+        $ref: '#/definitions/ServiceInstanceMetadata'
   ServiceInstanceUpdateRequest:
     type: object
     required:
@@ -689,7 +693,7 @@ definitions:
       instance_usable:
         type: boolean
       update_repeatable:
-        type: boolean 
+        type: boolean
   ServiceBindingResource:
     type: object
     properties:
@@ -749,9 +753,9 @@ definitions:
         items:
           $ref: '#/definitions/ServiceBindingVolumeMount'
   ServiceBindingMetadata:
-      properties:
-        expires_at:
-          type: string
+    properties:
+      expires_at:
+        type: string
   ServiceBindingVolumeMount:
     type: object
     required:
@@ -784,6 +788,11 @@ definitions:
       volume_id:
         type: string
       mount_config:
+        type: object
+  ServiceInstanceMetadata:
+    type: object
+    properties:
+      labels:
         type: object
   MaintenanceInfo:
     type: object


### PR DESCRIPTION
**What is the problem this PR solves?**

In this Pull Request, we introduce a new `ServiceInstanceMetadata` object that allows the Broker to associate specific `metadata`, more specifically `labels`, with Service Instances. By doing that Service Instances can be labelled with information defined by the Broker. The Platform can update its view of the `labels`. Service Instances with specific `labels` may be identified by Users via the Platform, in order to perform specific actions against those instances.

As an example, let's consider a MySQL Service Offering containing multiple Service Plans. A particular Service Plan combined with a specific set of parameters used in the Provision request could produce a Service Instance eligible for a [multi-source replication topology](https://dev.mysql.com/doc/refman/5.7/en/replication-multi-source.html). A User might want to take advantage of this feature and connect multiple MySQL Service Instances together. However, as not all existing MySQL Service Instances support multi-source replication, the User should be able to identify and select the eligible ones. This use case can be made possible by giving the Broker the ability to associate specific `labels` with Service Instances during a Provision or Update request, which will be returned to the Platform. The Platform can then store and make those `labels` available to the User, allowing them to identify and select the specific Service Instances.

The `ServiceInstanceMetadata` object follows a precedent established by the existing [BindingMetadata](https://github.com/dlresende/servicebroker/blob/master/spec.md#binding-metadata-object) object. We propose the creation of the `ServiceInstanceMetadata` object at the heart of the specification as opposed to a profile given the fact Platforms such as [Kubernetes](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/) and [Cloud Foundry](https://docs.cloudfoundry.org/adminguide/metadata.html#types) already have this concept.

**Checklist:**
- ✅ The [swagger.yaml](swagger.yaml) doc has been updated with any required changes
- ✅ The [openapi.yaml](openapi.yaml) doc has been updated with any required changes

@FelisiaM, @addytripathi & Diego