### PR TITLE
Update readme to reflect new call schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ version of the specification, however are still subject to change.
 
 - [Slack Channel](http://slack.openservicebrokerapi.org)
 - [Mailing List/Google Group](https://groups.google.com/forum/#!forum/open-service-broker-api)
-- [Weekly Call](https://github.com/openservicebrokerapi/servicebroker/wiki/Weekly-Call)
+- [Bi Weekly Call](https://github.com/openservicebrokerapi/servicebroker/wiki/Regular-Call)
 
 ## Contributing
 


### PR DESCRIPTION
**What is the problem this PR solves?**
I currently get notifications of people joining the call on the wrong weeks, maybe this will help. Once this is merged I'll rename the wiki page url to `Regular-Call`, keeping it general incase we increase/decrease frequency in the future.