### PR TITLE
Refine list of community brokers and associated components

### DIFF
--- a/gettingStarted.md
+++ b/gettingStarted.md
@@ -5,7 +5,8 @@
 - [Quickstarts](#quickstarts)
 - [Service Broker Libraries](#service-broker-libraries)
 - [Other Libraries](#other-libraries)
-- [Example Service Brokers](#example-service-brokers)
+- [Example Service Brokers](#example-and-community-service-brokers)
+- [Related community components](#related-community-components)
 
 # Introduction
 
@@ -72,6 +73,11 @@ implement an interface that uses the types from the
 [`Open Service Broker API for .NET`](https://github.com/AXOOM/OpenServiceBroker):
 .NET libraries for client and server implementations of the Open Service Broker API. The client library allows you to call Service Brokers that implement the API using idiomatic C# interfaces and type-safe DTOs. The server library implements the API for you using ASP.NET Core. You simply need to provide implementations for a few interfaces, shielded from the HTTP-related details.
 
+[spring-cloud-app-broker](https://github.com/spring-cloud/spring-cloud-app-broker)
+Spring Cloud App Broker is a framework for building Spring Boot applications that implement the Open Service Broker API to dynamically deploy Cloud Foundry applications.
+
+[Cloud service broker](https://github.com/pivotal/cloud-service-broker/)
+This service broker uses Terraform to provision and bind services.
 
 # Other Libraries
 
@@ -79,7 +85,7 @@ implement an interface that uses the types from the
 This library is a golang client for communicating with service brokers,
 useful for Platform developers.
 
-# Example Service Brokers
+# Example and Community Service Brokers
 
 ## Go
 
@@ -121,6 +127,22 @@ service brokers. The On Demand Broker is open source, and typically deployed via
 [Open Service Broker for Huawei Cloud](https://github.com/huaweicloud/huaweicloud-service-broker):
 This Service Broker implements support for Huawei cloud services.
 
+[World's Simplest Service Broker](https://github.com/cloudfoundry-community/worlds-simplest-service-broker) 
+This service broker shares the same binding credentials with everyone - for Kubernetes and Cloud Foundry 
+
+[Logs-service-broker](https://github.com/orange-cloudfoundry/logs-service-broker)
+A logs service broker to forward CloudFoundry [syslog drains](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md#log-drain) logs 
+to one or more syslog backends (http, tcp, or udp). This supports log parsing and transformation. 
+
+[Cf-redis-broker](https://github.com/pivotal-cf/cf-redis-broker/)
+A service broker for a shared redis cluster.
+
+[cf-rabbitmq-multitenant-broker](https://github.com/pivotal-cf/cf-rabbitmq-multitenant-broker-release/)
+a multi-tenant RabbitMQ service broker for Cloud Foundry.
+
+[mongodb-open-service-broker](https://github.com/orange-cloudfoundry/mongodb-boshrelease/tree/master/src/mongodb-open-service-broker)
+A service broker for a mongodb cluster
+
 ## Java
 
 [MySQL Java Broker](https://github.com/cloudfoundry-community/cf-mysql-java-broker):
@@ -132,3 +154,38 @@ enables platforms such as Cloud Foundry & Kubernetes to provision and manage
 services. It is built in a modular way and one can host multiple services.
 Open Service Broker offers extra functionality regarding billing,
 backup/restore on top of the Open Service Broker API.
+
+[Static credentials Broker](https://github.com/orange-cloudfoundry/static-creds-broker/) 
+This service broker serves statically configured data (catalog and service bindings)
+
+[Cassandra broker](https://github.com/orange-cloudfoundry/cassandra-boshrelease/tree/master/src/cassandra-open-service-broker)
+A service broker creating service instances as cassandra keyspaces and service bindings as cassandra roles.
+
+## Ruby
+
+[cf-mysql-broker](https://github.com/cloudfoundry-attic/cf-mysql-broker)
+A service broker for a shared mariadb cluster
+
+# Related community components
+
+[OSB CMDB](https://github.com/orange-cloudfoundry/osb-cmdb)
+A configuration management database for Service Brokers.  
+This enables sharing of service brokers among multiple OSB client platforms by providing inventory, events, quotas, analytics, etc...
+
+[OSB Reverse proxy](https://github.com/orange-cloudfoundry/osb-reverse-proxy)
+A reverse proxy for open service broker endpoints, providing recent remote access to logs of recent requests 
+
+[Overview broker](https://github.com/cloudfoundry/overview-broker)
+For the purpose of testing OSB client platforms, a service broker that provides an overview of its 
+service instances and bindings, its dashboard provides the full OSB API calls received.  
+
+[Peripli Service Manager](https://peripli.github.io/)
+The Service Manager is a component that manages Open Service Broker API compatible service brokers. 
+It can enforce polices on service brokers, instances and binding and enables cross-platform capabilities such as cross-platform service instance sharing.
+
+[Sec-group-broker-filter](https://github.com/orange-cloudfoundry/sec-group-broker-filter)
+A service broker designed to be chained in front-of other service brokers and dynamically open Cloud Foundry security groups 
+to let apps bound to service instance emmit outgoing traffic to IP addresses returned in the chained service instances credentials.
+
+[Subway](https://github.com/cloudfoundry-community/cf-subway)
+Subway is a multiplexing service broker that allows you to scale out single node brokers 


### PR DESCRIPTION
**What is the problem this PR solves?**

Completes the list of example service brokers and community components. 

Note: in the future, it might be worth moving full list of community brokers out of the getting-started.md file possibly in a `community-directory.md` linked from README.md

**Checklist:**
- [ ] The [swagger.yaml](swagger.yaml) doc has not been updated with any required changes: changes outside of spec
- [ ] The [openapi.yaml](openapi.yaml) doc has not been updated with any required changes: changes outside of spec
