### PR TITLE
Remove unsupported OpenAPI spec reference to JSON Schema

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -854,9 +854,9 @@ components:
         state:
           type: string
           enum:
-            - in_progress
-            - succeeded
-            - failed
+            - "in progress"
+            - "succeeded"
+            - "failed"
         description:
           type: string
         instance_usable:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4,6 +4,8 @@
 # the authority.
 
 openapi: "3.0.0"
+tags:
+- name: Open Service Broker API Specification
 
 info:
   title: Open Service Broker API
@@ -66,7 +68,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ServiceInstanceProvisionRequest'
+              $ref: '#/components/schemas/ServiceInstanceProvisionRequestBody'
       responses:
         '200':
           description: OK
@@ -135,7 +137,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/ServiceInstanceUpdateRequest'
+              $ref: '#/components/schemas/ServiceInstanceUpdateRequestBody'
       responses:
         '200':
           description: OK
@@ -723,24 +725,24 @@ components:
       type: object
       properties:
         create:
-          $ref: '#/components/schemas/SchemaParameters'
+          type: object
+          properties:
+            parameters:
+              type: object
         update:
-          $ref: '#/components/schemas/SchemaParameters'
+          type: object
+          properties:
+            parameters:
+              type: object
 
     ServiceBindingSchema:
       type: object
       properties:
         create:
-          $ref: '#/components/schemas/SchemaParameters'
-
-    SchemaParameters:
-      type: object
-      properties:
-        parameters:
-          $ref: '#/components/schemas/JSONSchema'
-
-    JSONSchema:
-      $ref: 'http://json-schema.org/draft-04/schema'
+          type: object
+          properties:
+            parameters:
+              type: object
 
     ServiceInstanceResource:
       type: object
@@ -758,7 +760,7 @@ components:
         metadata:
           $ref: '#/components/schemas/ServiceInstanceMetadata'
 
-    ServiceInstanceProvisionRequest:
+    ServiceInstanceProvisionRequestBody:
       type: object
       required:
         - service_id
@@ -807,7 +809,7 @@ components:
         attributes:
           type: object
 
-    ServiceInstanceUpdateRequest:
+    ServiceInstanceUpdateRequestBody:
       type: object
       required:
         - service_id
@@ -852,7 +854,7 @@ components:
         state:
           type: string
           enum:
-            - in progress
+            - in_progress
             - succeeded
             - failed
         description:


### PR DESCRIPTION
**What is the problem this PR solves?**

Remove the JSON Schema reference from the field and turn it into an object like the swagger file.
Adds required tags and an `_` to one of the states since spaces are not supported by OpenAPI when the field is an enum so the spec passes validation from tools like gnostic or openapi-generator.

**Checklist:**
- [x] The [swagger.yaml](swagger.yaml) doc has been updated with any required changes
- [x] The [openapi.yaml](openapi.yaml) doc has been updated with any required changes

Fixes #734 

After applying this changes openapi can generate bindings for any language without any issue:

```
openapi-generator generate -g protobuf-schema -i openapi.yaml -o protobuf
[main] INFO  o.o.codegen.DefaultGenerator - Generating with dryRun=false
[main] WARN  o.o.c.ignore.CodegenIgnoreProcessor - Output directory does not exist, or is inaccessible. No file (.openapi-generator-ignore) will be evaluated.
[main] INFO  o.o.codegen.DefaultGenerator - OpenAPI Generator: protobuf-schema (config)
[main] INFO  o.o.codegen.DefaultGenerator - Generator 'protobuf-schema' is considered beta.
[main] INFO  o.o.codegen.DefaultGenerator - Model Context not generated since it's a free-form object
[main] INFO  o.o.codegen.DefaultGenerator - Model Metadata not generated since it's a free-form object
[main] INFO  o.o.codegen.DefaultGenerator - Model Object not generated since it's a free-form object
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/async_operation.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/catalog.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/dashboard_client.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/error.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/last_operation_resource.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/maintenance_info.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/plan.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/schemas.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_binding_endpoint.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_binding_metadata.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_binding_request.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_binding_resouce_object.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_binding_resource.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_binding_response.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_binding_schema.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_binding_volume_mount.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_binding_volume_mount_device.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_instance_async_operation.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_instance_metadata.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_instance_previous_values.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_instance_provision_request_body.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_instance_provision_response.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_instance_resource.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_instance_schema.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_instance_schema_create.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/models/service_instance_update_request_body.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/services/catalog_service.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/services/service_bindings_service.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/services/service_instances_service.proto
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/README.md
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/.openapi-generator-ignore
[main] INFO  o.o.codegen.AbstractGenerator - writing file /Users/rvaz/Code/servicebroker/protobuf/.openapi-generator/VERSION
```