### PR TITLE
Reconcile service plan resource properties between OpenAPI (v2/3) and spec

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -712,6 +712,10 @@ components:
           type: boolean
         schemas:
           $ref: '#/components/schemas/Schemas'
+        maximum_polling_duration:
+          type: integer
+        plan_updateable:
+          type: boolean
 
     Schemas:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -716,6 +716,9 @@ components:
           type: integer
         plan_updateable:
           type: boolean
+        binding_rotatable:
+          type: boolean
+          default: false
 
     Schemas:
       type: object

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -568,6 +568,9 @@ definitions:
         type: integer
       maintenance_info:
         $ref: '#/definitions/MaintenanceInfo'
+      binding_rotatable:
+        type: boolean
+        default: false
   SchemasObject:
     type: object
     properties:


### PR DESCRIPTION
**What is the problem this PR solves?**

Adds missing properties to the service plan resource in both the Swagger and OpenAPI spec. Specifically:

To `openapi.yaml`:
- plan_updateable
- maximum_polling_duration
- binding_rotatable

To `swagger.yaml`:
- binding_rotatable

Fixes: #739

**Checklist:**
- [x] The [swagger.yaml](swagger.yaml) doc has been updated with any required changes
- [x] The [openapi.yaml](openapi.yaml) doc has been updated with any required changes
