### PR TITLE
Reconcile service binding resource between openapi versions

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -768,6 +768,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/ServiceBindingVolumeMount'
+      endpoints:
+        type: array
+        items:
+          $ref: '#/definitions/ServiceBindingEndpoint'
   ServiceBindingMetadata:
     type: object
     properties:

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -719,6 +719,10 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/ServiceBindingVolumeMount'
+      endpoints:
+        type: array
+        items:
+          $ref: '#/definitions/ServiceBindingEndpoint'
       parameters:
         type: object
   ServiceBindingRequest:
@@ -771,6 +775,25 @@ definitions:
         type: string
       renew_before:
         type: string
+  ServiceBindingEndpoint:
+    type: object
+    required:
+      - host
+      - ports
+    properties:
+      host:
+        type: string
+      ports:
+        type: array
+        items:
+          type: string
+      protocol:
+        type: string
+        enum:
+          - tcp
+          - udp
+          - all
+        default: tcp
   ServiceBindingVolumeMount:
     type: object
     required:


### PR DESCRIPTION
**What is the problem this PR solves?**

Adds missing endpoint object and properties to the `swagger.yaml` service binding resource / response.

Fixes: #741 

**Checklist:**
- [x] The [swagger.yaml](swagger.yaml) doc has been updated with any required changes
- [x] The [openapi.yaml](openapi.yaml) doc has been updated with any required changes
