### PR TITLE
Add ARM64 job in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@
 
 language: bash
 
+arch:
+  - amd64
+  - arm64
+
 services:
   - docker
 

--- a/tools/verify-all.sh
+++ b/tools/verify-all.sh
@@ -42,9 +42,9 @@ echo Verify spaces after periods
 "${REPODIR}/tools/verify-spaces.sh" -v "${REPODIR}"/spec.md "${REPODIR}"/profile.md "${REPODIR}"/compatibility.md || rc=1
 
 echo Verify OpenAPI
-docker run --rm -v "${REPODIR}":/local openapitools/openapi-generator-cli:v4.2.3 validate -i /local/openapi.yaml || rc=1
+docker run --rm -v "${REPODIR}":/local openapitools/openapi-generator-cli:v5.1.1 validate -i /local/openapi.yaml || rc=1
 
 echo Verify Swagger
-docker run --rm -v "${REPODIR}":/local openapitools/openapi-generator-cli:v4.2.3 validate -i /local/swagger.yaml || rc=1
+docker run --rm -v "${REPODIR}":/local openapitools/openapi-generator-cli:v5.1.1 validate -i /local/swagger.yaml || rc=1
 
 exit $rc


### PR DESCRIPTION
Patch Details: Following files has been modified :
travis.yml: Added arm64 architecture in travis.yml
tools/verify-all.sh: Modified verify-all.sh file by updating the version of docker image for package openapi-generator-cli which is supported on arm64 platform

Signed-off-by: odidev odidev@puresoftware.com